### PR TITLE
feat: Add GitHub Pages deployment and improved packaging

### DIFF
--- a/stock_analyzer/.github/workflows/ci.yml
+++ b/stock_analyzer/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
     paths:
       - 'stock_analyzer/**'
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build_and_lint:
     runs-on: ubuntu-latest
@@ -49,9 +54,25 @@ jobs:
     - name: Build project
       run: npm run build
 
-    # Add a step to upload build artifacts if needed for deployment
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+    - name: Prepare deployment package
+      run: |
+        mkdir -p staging_dir/dist
+        cp -r dist/* staging_dir/dist/
+        cp index.html staging_dir/
+        cp index.css staging_dir/
+        cp sw.js staging_dir/
+        cp manifest.json staging_dir/
+      working-directory: ./stock_analyzer
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+
+    - name: Upload artifact for GitHub Pages
+      uses: actions/upload-pages-artifact@v3
       with:
-        name: stock-analyzer-build
-        path: stock_analyzer/dist/ # Or wherever your build output is
+        # Upload entire staging directory
+        path: ./stock_analyzer/staging_dir # Path is relative to GITHUB_WORKSPACE
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/stock_analyzer/README.md
+++ b/stock_analyzer/README.md
@@ -29,16 +29,34 @@ This application provides stock projection analysis.
     npm run build
     ```
 
-## Running the Application
+## Running the Application Locally
 
-After building the project, you can open the `index.html` file in your browser. For a better experience, serve the `stock_analyzer` directory using a local web server. Many simple HTTP servers are available, for example, `serve` (which you can install via `npm install -g serve` and then run `serve .` from within the `stock_analyzer` directory).
+After building the project (`npm run build`), the necessary files will be in the `dist` directory. To run locally:
+1.  Ensure `index.html`, `index.css`, `sw.js`, and `manifest.json` are in the same root directory as the `dist` folder. (The GitHub action prepares this structure for deployment).
+2.  Serve the root directory (e.g., `stock_analyzer` if you manually copied `dist` contents, or the root of the downloaded artifact) using a local web server. For example, using `serve`:
+    ```bash
+    # If you have 'serve' installed globally
+    serve .
+    ```
+    Then open `index.html` in your browser.
 
-The application expects `index.html`, `dist/bundle.js`, and `sw.js` to be served from the same root.
+## Deployment to GitHub Pages
 
-## GitHub Actions
+This application is automatically built and deployed to GitHub Pages when changes are pushed to the `main` branch.
 
-A CI workflow is set up in `.github/workflows/ci.yml`. It will:
-- Install dependencies.
-- Run type checks.
-- Build the project.
-- Upload the build output (`dist` directory) as an artifact named `stock-analyzer-build`.
+You should be able to access the live application at a URL similar to:
+`https://<your-github-username>.github.io/<your-repository-name>/`
+
+*(Note: You may need to configure the correct path in your repository settings if you are deploying a sub-directory or if your repository serves multiple projects.)*
+
+## GitHub Actions Workflow
+
+The CI/CD workflow is defined in `.github/workflows/ci.yml`. It performs the following key steps:
+- Installs dependencies.
+- Runs type checks.
+- Builds the project.
+- Prepares a runnable package (including `index.html`, `css`, `sw.js`, `manifest.json`, and the `dist` build output).
+- Uploads this package as an artifact for GitHub Pages deployment.
+- Deploys the application to GitHub Pages.
+
+The artifact uploaded for GitHub Pages (typically named `github-pages`) can also be downloaded from the workflow run summary if you need a packaged version of the application.


### PR DESCRIPTION
Enhances the GitHub Actions workflow to:
1.  Prepare a complete runnable package by copying `index.html`, `index.css`, `sw.js`, `manifest.json` alongside the `dist` directory into a staging area.
2.  Upload this staging area as an artifact suitable for GitHub Pages deployment (using `actions/upload-pages-artifact`).
3.  Automatically deploy the application to GitHub Pages on pushes to the main branch (using `actions/configure-pages` and `actions/deploy-pages`).
4.  Appropriate permissions (`pages: write`, `id-token: write`) have been added to the workflow for deployment.

Updates `stock_analyzer/README.md` to:
- Include a "Deployment to GitHub Pages" section with the expected URL.
- Detail the workflow's new deployment and packaging steps.
- Clarify how to run the application locally from the build or downloaded artifact.

This makes the application automatically deployable and provides a more complete runnable artifact from the CI.