### PR TITLE
feat: Implement iframe/image toggle for user lists

### DIFF
--- a/best/ui.js
+++ b/best/ui.js
@@ -48,6 +48,10 @@ class UIManager {
         userElement.innerHTML = `
             <div class="user-image-container">
                 <img src="${user.image_url}" alt="${user.username} thumbnail" loading="lazy" class="w3-image">
+                <div class="iframe-preview-container">
+                    <iframe src="https://chaturbate.com/embed/${user.username}/?tour=dU9X&campaign=9cg6A&disable_sound=1&bgcolor=black" allow="autoplay; encrypted-media; picture-in-picture" sandbox="allow-scripts allow-same-origin allow-presentation" title="${user.username} preview"></iframe>
+                </div>
+                <button class="toggle-view-btn">Show Preview</button>
                 ${removeButtonHTML}
             </div>
             <div class="user-details w3-container w3-padding-small">
@@ -65,6 +69,22 @@ class UIManager {
             event.preventDefault();
             handleUserClickCallback(user);
         });
+
+        const toggleBtn = userElement.querySelector('.toggle-view-btn');
+        if (toggleBtn) {
+            toggleBtn.addEventListener('click', function(event) {
+                event.stopPropagation(); // Prevent the main user card click event
+                const imageContainer = this.closest('.user-image-container');
+                if (imageContainer) {
+                    imageContainer.classList.toggle('iframe-active');
+                    if (imageContainer.classList.contains('iframe-active')) {
+                        this.textContent = 'Show Image';
+                    } else {
+                        this.textContent = 'Show Preview';
+                    }
+                }
+            });
+        }
 
         const removeBtn = userElement.querySelector('.remove-user-btn');
         if (removeBtn) {


### PR DESCRIPTION
This commit introduces an iframe/image toggle feature to user cards in both the 'Online Users' and 'Previous Users' lists.

The `UIManager.createUserElement` method in `best/ui.js` has been updated to:
- Include the necessary HTML structure for an iframe preview and a toggle button within each user's image container.
- Add an event listener to the toggle button. This listener toggles an 'iframe-active' class on the image container and updates the button text (e.g., "Show Preview" / "Show Image").

The functionality relies on existing CSS in `best/style.css` for the visual presentation and toggling behavior. This change extends the previously implemented toggle (which was CSS-only for the Online Users list) to be fully functional and available on both lists.

The auto-scroll capability of the user lists (i.e., standard browser scrolling for overflowing content) is maintained through existing CSS.