### PR TITLE
fix: Ensure user list columns correctly scroll without pushing iframes

### DIFF
--- a/best/script.js
+++ b/best/script.js
@@ -843,7 +843,8 @@
                     const userColumns = document.querySelectorAll('.user-column');
                     userColumns.forEach(column => {
                         column.style.maxHeight = calculatedHeight + 'px';
-                        console.log('App: Applied max-height to user column:', column.id || 'N/A');
+                        column.style.overflow = 'hidden'; // Add this line
+                        console.log('App: Applied max-height and overflow:hidden to user column:', column.id || 'N/A');
                     });
                 } else {
                     console.warn('App: Iframe column height is 0, not adjusting user column heights.');

--- a/best/style.css
+++ b/best/style.css
@@ -141,6 +141,7 @@ h2 {
     overflow-y: auto; /* Enable vertical scrolling */
     flex-grow: 1; /* Allow list to fill remaining space in column */
     padding-right: 5px; /* Space for scrollbar */
+    min-height: 0; /* Add this line */
 }
 
 /* Individual User Card Styling */


### PR DESCRIPTION
This commit resolves an issue where the 'Online Users' and 'Previous Users' columns could extend beyond their intended height, causing the main page to scroll and move the iframe viewers.

The following adjustments were made:

1.  **JavaScript (`best/script.js`):**
    - The `App.#adjustLayoutHeights` method, which sets the `max-height` of user columns based on the iframe column's height, was updated to also set `column.style.overflow = 'hidden';` on each `.user-column`. This strictly prevents the user column itself from displaying scrollbars or expanding due to its content.

2.  **CSS (`best/style.css`):**
    - The `.user-list` CSS rule was updated to include `min-height: 0;`. This helps ensure that as a flex child, it can shrink appropriately to fit within the height constraints defined by its parent (`.user-column`), especially when the parent has a `max-height`.

With these changes, the `.user-column` divs are strictly height-limited to match the `.iframe-column`. The `.user-list` divs within them will use `flex-grow: 1` to fill that constrained space and `overflow-y: auto` to scroll their content internally, keeping the iframes stationary and visible as intended.