### PR TITLE
I've added a side panel for lesson navigation.

### DIFF
--- a/study/index.html
+++ b/study/index.html
@@ -194,6 +194,7 @@
              display: none;
          }
 
+        /* Styles for lesson titles panel and related elements are now in style.css */
 
     </style>
 </head>
@@ -218,25 +219,39 @@
              <button class="w3-button w3-border w3-round-large topic-btn" data-topic="advanced_quant_finance">Advanced Quant Finance</button>
         </div>
 
-        <!-- Lesson Display Area -->
-        <div class="lesson-container w3-card w3-padding w3-round-large w3-white">
-            <!-- Title - becomes clickable once a topic is loaded -->
-            <h1 id="lesson-title" class="w3-large w3-center">Please Select a Topic Above</h1>
+        <!-- NEW: Main container for side panel and lesson content -->
+        <div id="study-area-container" class="w3-row">
 
-            <!-- Progress Bar - Make the container clickable -->
-            <div class="progress-bar-container w3-light-grey w3-round">
-                <div id="progress-bar" class="w3-green w3-round" style="width:0%"></div>
+            <!-- NEW: Side Panel for Lesson Titles -->
+            <div id="lesson-titles-panel" class="w3-col m3 l3 w3-card w3-padding w3-light-grey">
+                <h4 class="w3-center">Lessons</h4>
+                <div id="lesson-list-container">
+                    <!-- Lesson titles will be populated here by script.js -->
+                    <p class="instructions">Select a topic to see lessons.</p>
+                </div>
             </div>
 
-            <!-- Lesson Content Area -->
-            <div id="lesson-content" class="w3-light-grey w3-padding w3-round-large">
-                <p class="instructions">Welcome! Choose a subject from the buttons above to load lessons on that topic.</p>
-                 <!-- Disclaimer for Options / Finance (Initially hidden, JS will show if needed) -->
-                 <div id="options-disclaimer" class="w3-panel w3-pale-yellow w3-border w3-leftbar w3-border-yellow">
-                     <strong>Disclaimer:</strong> Content on financial markets and options trading involves substantial risk and is for educational purposes only. It does not constitute financial advice. Consult a qualified professional before making any decisions.
-                 </div>
+            <!-- EXISTING: Lesson Display Area (now part of flex) -->
+            <div class="lesson-container w3-col m9 l9 w3-card w3-padding w3-round-large w3-white" style="flex-grow: 1;">
+                <!-- Title - becomes clickable once a topic is loaded -->
+                <h1 id="lesson-title" class="w3-large w3-center">Please Select a Topic Above</h1>
+
+                <!-- Progress Bar - Make the container clickable -->
+                <div class="progress-bar-container w3-light-grey w3-round">
+                    <div id="progress-bar" class="w3-green w3-round" style="width:0%"></div>
+                </div>
+
+                <!-- Lesson Content Area -->
+                <div id="lesson-content" class="w3-light-grey w3-padding w3-round-large">
+                    <p class="instructions">Welcome! Choose a subject from the buttons above to load lessons on that topic.</p>
+                     <!-- Disclaimer for Options / Finance (Initially hidden, JS will show if needed) -->
+                     <div id="options-disclaimer" class="w3-panel w3-pale-yellow w3-border w3-leftbar w3-border-yellow">
+                         <strong>Disclaimer:</strong> Content on financial markets and options trading involves substantial risk and is for educational purposes only. It does not constitute financial advice. Consult a qualified professional before making any decisions.
+                     </div>
+                </div>
             </div>
-        </div>
+
+        </div> <!-- End study-area-container -->
 
         <!-- Calendar Section -->
         <div id="calendar-container" class="w3-container w3-margin-top w3-card w3-padding w3-round-large w3-white" style="width:100%;">

--- a/study/style.css
+++ b/study/style.css
@@ -241,3 +241,56 @@ em { font-style: italic; color: #8e44ad; }
     border-top: 1px solid #ddd;
     background-color: #f9f9f9 !important; /* Override w3-light-grey if needed for more distinction */
 }
+
+/* === Styles for Study Area Layout and Lesson Titles Panel === */
+#study-area-container {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    margin-bottom: 20px; /* Spacing before calendar/next section */
+}
+
+#lesson-titles-panel {
+    /* w3-col m3 l3 classes handle width */
+    /* w3-card, w3-padding, w3-light-grey handle base style from HTML */
+    max-height: 65vh; /* Match lesson content max height */
+    overflow-y: auto;
+    margin-right: 16px; /* Space between panel and lesson content */
+    margin-bottom: 16px; /* Space if items wrap on small screens */
+}
+
+#lesson-list-container ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+#lesson-list-container li.lesson-link {
+    padding: 8px 10px;
+    margin-bottom: 5px;
+    background-color: #f8f9fa; /* Light default background */
+    border-radius: 4px;
+    cursor: pointer;
+    border-left: 5px solid transparent;
+    transition: background-color 0.2s ease, border-left-color 0.2s ease;
+    font-size: 0.95em;
+}
+
+#lesson-list-container li.lesson-link:hover {
+    background-color: #e9ecef; /* Adjusted hover color */
+}
+
+#lesson-list-container li.lesson-link.active-lesson-link {
+    background-color: #e0e6ed; /* Adjusted active background */
+    font-weight: bold;
+    color: #2c3e50; /* Darker text for active link */
+    border-left: 5px solid #007bff; /* Brighter blue for active lesson */
+}
+
+#lesson-list-container .instructions {
+    padding: 10px;
+    font-size: 0.9em;
+    color: #6c757d; /* Bootstrap secondary text color like */
+    text-align: center;
+}
+/* === End Styles for Study Area Layout === */


### PR DESCRIPTION
I implemented a side panel to display lesson titles for the selected topic.

Changes include:
- Modified `study/index.html` to add the side panel structure next to the lesson content area.
- Updated `study/script.js` to:
    - Dynamically populate the side panel with lesson titles.
    - Enable navigation by clicking lesson titles in the panel.
    - Highlight the currently active lesson in the side panel.
    - Handle logging of partial lesson durations when switching lessons via the side panel.
- Moved and refined CSS for the side panel and its elements to `study/style.css`.