### PR TITLE
I've updated the W3.CSS column classes for the lesson titles side pan…

### DIFF
--- a/study/index.html
+++ b/study/index.html
@@ -223,7 +223,7 @@
         <div id="study-area-container" class="w3-row">
 
             <!-- NEW: Side Panel for Lesson Titles -->
-            <div id="lesson-titles-panel" class="w3-col m3 l3 w3-card w3-padding w3-light-grey">
+            <div id="lesson-titles-panel" class="w3-col s12 m3 l3 w3-card w3-padding w3-light-grey">
                 <h4 class="w3-center">Lessons</h4>
                 <div id="lesson-list-container">
                     <!-- Lesson titles will be populated here by script.js -->
@@ -232,7 +232,7 @@
             </div>
 
             <!-- EXISTING: Lesson Display Area (now part of flex) -->
-            <div class="lesson-container w3-col m9 l9 w3-card w3-padding w3-round-large w3-white" style="flex-grow: 1;">
+            <div class="lesson-container w3-col s12 m9 l9 w3-card w3-padding w3-round-large w3-white" style="flex-grow: 1;">
                 <!-- Title - becomes clickable once a topic is loaded -->
                 <h1 id="lesson-title" class="w3-large w3-center">Please Select a Topic Above</h1>
 


### PR DESCRIPTION
…el and the main lesson content area. This will ensure they stack vertically on small screens and display side-by-side on medium and large screens.

Specifically:
- `lesson-titles-panel` is now `w3-col s12 m3 l3`.
- `lesson-container` is now `w3-col s12 m9 l9`.
- I also verified that the parent `study-area-container` uses `display: flex` and `flex-wrap: wrap` to support this responsive behavior.