### PR TITLE
I've updated the layout in the 'best' directory by moving 'History' t…

### DIFF
--- a/best/index.html
+++ b/best/index.html
@@ -140,14 +140,14 @@
         <!-- Main Content Area (Columns) -->
         <div class="main-content">
 
-            <!-- Online Users Column -->
-            <div class="user-column" id="onlineUsers">
-                <h2>Online Users</h2>
-                <div id="onlineLoadingIndicator" class="loading-indicator" style="display: none;">Loading...</div>
-                <div id="onlineErrorDisplay" class="error-message" style="display: none;"></div>
-                <div class="user-list">
-                    <!-- User cards will be added here by JS -->
-                </div>
+            <!-- Previous Users Column -->
+            <div class="user-column" id="previousUsers">
+                 <h2>History (Online Now)</h2>
+                 <button id="clearPreviousUsers" class="clear-history-btn">Clear History</button>
+                 <div class="user-list">
+                     <!-- Previous user cards will be added here by JS -->
+                     <p class="text-muted w3-center">Loading history...</p> <!-- Initial placeholder -->
+                 </div>
             </div>
 
             <!-- Main Viewing Column -->
@@ -180,14 +180,14 @@
                 </div>
             </div>
 
-            <!-- Previous Users Column -->
-            <div class="user-column" id="previousUsers">
-                 <h2>History (Online Now)</h2>
-                 <button id="clearPreviousUsers" class="clear-history-btn">Clear History</button>
-                 <div class="user-list">
-                     <!-- Previous user cards will be added here by JS -->
-                     <p class="text-muted w3-center">Loading history...</p> <!-- Initial placeholder -->
-                 </div>
+            <!-- Online Users Column -->
+            <div class="user-column" id="onlineUsers">
+                <h2>Online Users</h2>
+                <div id="onlineLoadingIndicator" class="loading-indicator" style="display: none;">Loading...</div>
+                <div id="onlineErrorDisplay" class="error-message" style="display: none;"></div>
+                <div class="user-list">
+                    <!-- User cards will be added here by JS -->
+                </div>
             </div>
 
         </div> <!-- End Main Content -->


### PR DESCRIPTION
…o the left and 'Online Users' to the right.

Specifically, I reordered the columns in `best/index.html`. The 'History' section (#previousUsers) is now to the left of the 'Viewer' section (.iframe-column), and the 'Online Users' section (#onlineUsers) is on the right.

I also confirmed that the existing CSS handles this new order correctly across different screen sizes, ensuring it remains responsive for desktop, tablet, and mobile views according to the media queries.