### PR TITLE
Feat: Add calendar templates and apply global color theme

### DIFF
--- a/church_school_lesson_plan/AGENTS.md
+++ b/church_school_lesson_plan/AGENTS.md
@@ -1,77 +1,81 @@
-# AGENTS.md - Church School Lesson Plan Structure (Ages 6-7)
+# AGENTS.md - Church School Lesson Plan Structure for Mrs. Scott (Ages 6-7)
 
-This directory contains a structured set of HTML templates and guidelines for developing a church school lesson plan curriculum, specifically tailored for children aged 6-7 years old. All templates are styled with W3.CSS (linked via CDN) for better visual presentation when viewed in a web browser.
+This directory contains a structured set of HTML templates and guidelines designed to assist **Mrs. Scott** in developing a rich and engaging church school lesson plan curriculum. It is specifically tailored for children aged 6-7 years old. All templates are styled with W3.CSS (linked via CDN) for better visual presentation when viewed in a web browser.
 
 ## Core Philosophy: Teacher Autonomy & Adaptability
 
-*   **You are the Curriculum Shaper:** These templates provide a framework, not a rigid script. You, the teacher, have the final say on all lesson content.
-*   **Full Editability:** All HTML template files are fully editable. Modify, add, or remove content to suit your specific needs, theological emphases, and church traditions.
-*   **Audience Analysis is Key:** Each school year brings a unique group of children. **It is crucial to adapt lesson plans based on an initial and ongoing analysis of your students.** This includes understanding their developmental stages (within the 6-7 range), prior knowledge, interests, learning styles, and any specific needs. This analysis will guide your choice of stories, activities, pacing, and complexity.
-*   **Populate to Create Your Semester:** This structure is designed for you to populate with your detailed lesson plans, stories, activities, and resources to build out a full semester's or year's worth of material.
+*   **Mrs. Scott is the Curriculum Shaper:** These templates provide a robust framework, not a rigid script. Mrs. Scott has the final say on all lesson content, adapting it to the unique needs of her students and the specific goals of her ministry.
+*   **Full Editability:** All HTML template files are fully editable. Mrs. Scott should feel empowered to modify, add, or remove content to suit her specific needs, theological emphases, church traditions, and the insights she gains from her students.
+*   **Audience Analysis is Key:** Each school year brings a unique group of children. **It is crucial for Mrs. Scott to adapt lesson plans based on an initial and ongoing analysis of her students.** This includes understanding their developmental stages (within the 6-7 range), prior knowledge, interests, learning styles, and any specific needs. This analysis will guide her choice of stories, activities, pacing, and complexity.
+*   **Populate to Create Your Semester/Year:** This structure is designed for Mrs. Scott to populate with her detailed lesson plans, stories, activities, and resources, building out a full semester's or year's worth of material. The "length" and richness of the overall lesson plan system will grow significantly as she does this.
 
 ## How to Use This Structure:
 
-1.  **Understand the File Format:** All templates are now `.html` files. You can open them in a web browser to view their styled layout or open them in a text editor (or HTML editor) to modify their content.
+1.  **Understand the File Format:** All primary templates are `.html` files. Mrs. Scott can open them in a web browser to view their styled layout or open them in a text editor (or HTML editor) to modify their content.
     *   Styling is provided by W3.CSS, linked from a CDN in the `<head>` of each HTML file.
 
-2.  **Understand the Age Focus:** All materials and templates are designed with 6-7 year olds in mind. This means activities should be hands-on, engaging, and relatively short. Concepts should be concrete and relatable. Language should be simple.
+2.  **Understand the Age Focus:** All materials and templates are designed for 6-7 year olds. Activities should be hands-on, engaging, and relatively short. Concepts should be concrete and relatable. Language should be simple.
 
-3.  **Start with the Big Picture:**
-    *   Review `school_year_structure_considerations.html` to think about how your overall year, terms, and special events will flow.
-    *   Consult `subject_areas_overview.html` to understand the recommended subjects and their general scope for this age group. Prioritize and expand on subjects according to your specific educational goals and the time available.
+3.  **Start with the Big Picture (`yearly_overview_template.html`, `school_year_structure_considerations.html`, `subject_areas_overview.html`):**
+    *   Use `lesson_calendars/yearly_overview_template.html` to map out major themes, units, holidays, and term dates for the entire year. This provides a high-level roadmap.
+    *   Review `school_year_structure_considerations.html` for further guidance on structuring terms and pacing.
+    *   Consult `subject_materials/subject_areas_overview.html` to understand the recommended subjects. Mrs. Scott should prioritize and expand on subjects according to her specific educational goals and available class time.
 
-4.  **Daily/Weekly Planning:**
-    *   Use `daily_schedules/sample_daily_schedule_template.html` as a guide for structuring individual class days. Adapt the timing and content based on your specific class length (2-8 hours) and the topics for the day, informed by your audience analysis.
+4.  **Monthly and Weekly Planning (using `lesson_calendars/` templates):**
+    *   **Monthly View:** Copy `lesson_calendars/monthly_calendar_template.html` (e.g., to `lesson_calendars/september_2024_calendar.html`). Mrs. Scott can then fill in this calendar with:
+        *   Lesson titles or brief summaries for each class day.
+        *   Direct links to her specific daily lesson plan files (see next point).
+        *   Notes for holidays or special events occurring that month.
+    *   **Weekly View:** Copy `lesson_calendars/weekly_calendar_template.html` (e.g., `lesson_calendars/week_of_sept_9_2024_calendar.html`). This template allows for more detail for each day of the week, such as:
+        *   Lesson Title / Theme for the day.
+        *   Key Activities / Focus Points.
+        *   Scripture Focus.
+        *   Key Materials needed.
+        *   A direct link to the full Daily Lesson Plan file.
+    *   These calendar views help organize the flow of lessons and provide an at-a-glance overview.
 
-5.  **Developing Subject Content:**
-    *   For each subject or thematic unit you plan, use `subject_materials/subject_unit_template.html`. This will help you detail:
-        *   Learning objectives (adapted for your current students)
-        *   Lesson activities (broken down, chosen for engagement)
-        *   Required resources
-        *   Assessment ideas
-        *   Integration with other subjects
-        *   Differentiation/Adaptation notes for diverse learners.
+5.  **Detailed Daily Lesson Planning (`daily_schedules/sample_daily_schedule_template.html`):**
+    *   This is the core template for planning each individual class session (1.5 to 6 hours long).
+    *   Mrs. Scott should copy this template for each class day (e.g., `daily_schedules/lesson_plan_sept_9_2024.html`) and fill it with specific timings, activities, Bible stories, literacy/numeracy focuses, crafts, music, etc., tailored to that day's objectives and her students' needs.
+    *   The information from these detailed daily plans can then be summarized or linked in the weekly/monthly calendar views.
 
-6.  **Classroom Management Resources (`classroom_management_resources/`):**
+6.  **Developing Subject Content (`subject_materials/subject_unit_template.html`):**
+    *   For each thematic unit or extended study on a particular subject (e.g., a 4-week unit on Moses), Mrs. Scott should use the `subject_unit_template.html`. This helps detail:
+        *   Learning objectives (adapted for her current students).
+        *   Lesson breakdowns and activities (chosen for engagement).
+        *   Required resources, assessment ideas, and cross-curricular integration.
+        *   Differentiation notes for diverse learners.
+
+7.  **Classroom Management Resources (`classroom_management_resources/`):**
     *   `attendance_sheet_template.html`: For tracking daily/weekly attendance.
     *   `group_management_template.html`: To help organize students for group work.
     *   `emergency_contact_form_template.html`: **Crucial for student safety.**
-        *   **IMPORTANT:** This form collects sensitive personal data. Ensure it is printed, completed by parents/guardians, and then **stored securely and confidentially** according to your church's privacy and child safety policies. Digital storage of completed forms within this general folder structure is **not recommended** unless the environment is specifically secured for such private data.
+        *   **VERY IMPORTANT, MRS. SCOTT:** This form collects sensitive personal data. Ensure it is printed, completed by parents/guardians, and then **stored securely and confidentially** according to your church's privacy and child safety policies. Digital storage of completed forms within this general folder structure is **not recommended** unless the environment is specifically secured for such private data.
 
-7.  **Assessment (`assessments/`):**
-    *   Consult `grading_and_feedback_philosophy.html` for principles on age-appropriate assessment for 6-7 year olds, including notes on observing holistic development and skills relevant to "life roles." Remember, your role is to provide opportunities for growth and to observe, not to make definitive judgments about a child's entire future.
-    *   `student_grades_template.html`: A styled template for manually recording observations, participation, and results from various assessments. This is for your interpretation of student work and progress.
-    *   `quiz_template.html`: For simple, periodic checks of understanding.
-    *   `midterm_review_ideas.html`: For engaging, holistic review sessions.
-    *   `final_project_ideas_template.html`: For planning culminating projects.
-    *   Assessment for this age group should be informal, observational, and encouraging.
+8.  **Assessment (`assessments/`):**
+    *   Consult `grading_and_feedback_philosophy.html` for principles on age-appropriate assessment, including notes on observing holistic development and skills relevant to "life roles." Mrs. Scott's role is to provide opportunities for growth and to observe, not to make definitive judgments about a child's entire future based on these early years.
+    *   `student_grades_template.html`: A styled template for manually recording observations, participation, and results from various assessments. This is for Mrs. Scott's interpretation of student work and progress.
+    *   Other templates: `quiz_template.html`, `midterm_review_ideas.html`, `final_project_ideas_template.html`.
+    *   Remember, assessment for this age group should be primarily informal, observational, and encouraging.
 
-8.  **Projects (`projects/`):**
-    *   If planning larger, multi-session projects, use `project_outline_template.html` to structure the goals, steps, and materials.
-
-9.  **Events & Awards (`events_and_awards/`):**
-    *   `annual_events_calendar_template.html`: To map out special events and celebrations.
-    *   `weekly_prize_system.html`: Optional guide for a fun, random prize system.
-
-10. **Optional Reinforcement (`homework_optional/`):**
-    *   `homework_classwork_ideas.html` provides suggestions for optional take-home activities or in-class extensions. Keep these genuinely optional and low-pressure.
+9.  **Projects, Events, Extras (`projects/`, `events_and_awards/`, `homework_optional/`, `story_resources/`):**
+    *   Utilize templates like `project_outline_template.html`, `annual_events_calendar_template.html`, `field_trip_planning_template.html`, `weekly_prize_system.html`, and `homework_classwork_ideas.html` as needed.
+    *   The story `story_resources/the_little_helping_seed.html` is provided as an example resource. Mrs. Scott can add more stories or link to external ones.
 
 ## Expanding This Structure:
 
-*   **Populate with Specific Content:** Your main task will be to take these HTML templates, save copies (e.g., `fall_semester_week1_schedule.html`), and fill them with your specific Bible stories, themes, activities, and resources.
-    *   For example, under `subject_materials/`, you might create subfolders for each main subject (e.g., `subject_materials/bible_stories/`).
-    *   Within these, you could save completed `subject_unit_template.html` files for each unit (e.g., `subject_materials/bible_stories/noahs_ark_unit.html`).
-*   **Add Resource Lists:** You might create separate HTML files for lists of recommended books, songs, websites, or craft supply sources.
-*   **Visuals:** Remember that for 6-7 year olds, visual aids are crucial. Note down your visual aid needs in the lesson plans. You might store digital copies of printables or links to online images in relevant folders.
-*   **Consistency:** When adding new lesson plans or units, try to follow the structure provided in `subject_unit_template.html` for consistency.
+*   **Populate with Specific Content:** Mrs. Scott's main task will be to take these HTML templates, save copies (e.g., `unit_moses_overview.html`, `daily_lesson_oct5.html`), and fill them with her specific Bible stories, chosen activities, resource lists, etc. The more detailed she makes these, the more "lengthy" and valuable the overall system becomes.
+*   **Create Subfolders:** For better organization, especially within `subject_materials/` or `daily_schedules/`, Mrs. Scott might create subfolders for terms, months, or specific units (e.g., `subject_materials/advent_unit/`, `daily_schedules/fall_term/`).
+*   **Add Resource Lists:** Consider creating separate HTML files for comprehensive lists of recommended books, songs, websites, or craft supply sources.
+*   **Visuals:** Note visual aid needs in lesson plans. Digital copies of printables or links to online images can be stored in relevant folders or linked from plans. More extensive art can be added to the site or individual pages later by editing the HTML.
 
 ## Key Considerations for 6-7 Year Olds (Reiteration):
 
-*   **Active Learning:** Incorporate movement, songs, games, and hands-on activities.
-*   **Storytelling:** Bible stories are central. Use engaging storytelling techniques.
-*   **Repetition:** Young children benefit from repetition of key concepts and verses.
+*   **Active Learning:** Incorporate movement, songs, games, hands-on activities.
+*   **Storytelling:** Bible stories are central. Use engaging techniques.
+*   **Repetition:** Beneficial for young children.
 *   **Positive Reinforcement:** Encourage participation and effort.
-*   **Flexibility:** Be prepared to adapt lessons based on children's responses and needs – this is where your audience analysis comes into play daily!
+*   **Flexibility:** Crucial! Be prepared to adapt lessons based on children's responses and needs – this is where Mrs. Scott's ongoing audience analysis is vital.
 *   **Faith Integration:** Continuously connect lessons back to God's love and Christian values.
 
-This framework is intended to be a helpful and flexible starting point. May God bless your ministry to the children!
+This framework is intended to be a helpful and flexible starting point for Mrs. Scott. May God bless your ministry to the children!

--- a/church_school_lesson_plan/assessments/final_project_ideas_template.html
+++ b/church_school_lesson_plan/assessments/final_project_ideas_template.html
@@ -6,21 +6,34 @@
     <title>Final Project Ideas & Planning Template (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --theme-color-table-header: #a33a3a; /* Medium-dark red for table headers */
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 100px; display: inline-block; margin-bottom: 5px; }
-        .full-width-editable { background-color: #f0f0f0; padding: 5px; border: 1px dotted #ccc; width: 100%; min-height: 40px; display: block; margin-bottom:5px;}
+        .full-width-editable { background-color: #f0f0f0; padding: 5px; border: 1px dotted #ccc; width: 100%; min-height: 40px; display: block; margin-bottom:5px; box-sizing: border-box;}
         .project-idea { margin-bottom: 15px; }
-        .w3-table-all th, .w3-table-all td { padding: 8px; vertical-align: top;}
+        .project-idea h4 {color: var(--theme-color-dark-accent); }
+        .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
+        .w3-table-all td { padding: 8px; vertical-align: top;}
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .section-heading { color: var(--theme-color-main); border-bottom: 2px solid var(--theme-color-main); padding-bottom: 5px; }
+        .subsection-heading { color: var(--theme-color-dark-accent); }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Final Project Ideas & Planning Template (6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card">
         <p><strong>Purpose:</strong> To provide a culminating activity that allows children to demonstrate their learning and understanding of key themes, stories, and values from the year/term in a creative and engaging way. This should be a celebration of learning.</p>
         <p><strong>Theme (if applicable, e.g., "Living like Jesus," "God's Big Story"):</strong> <span class="editable">_________________________</span></p>
     </div>
@@ -28,38 +41,38 @@
     <hr>
 
     <div class="w3-card w3-padding w3-margin-bottom">
-        <h2 class="w3-text-blue w3-border-bottom">Possible Final Project Formats:</h2>
+        <h2 class="section-heading">Possible Final Project Formats:</h2>
         <div class="w3-row-padding">
             <div class="w3-half">
-                <div class="project-idea w3-panel w3-leftbar w3-border-blue w3-hover-shadow">
+                <div class="project-idea w3-panel w3-leftbar w3-border-red w3-hover-shadow"> <!-- Changed border color to theme -->
                     <h4>1. Class Bible Story Re-enactment/Play:</h4>
                     <p><strong>Description:</strong> The class works together to choose a favorite Bible story (or a compilation of scenes) to act out.</p>
                     <p><strong>Roles:</strong> Simple speaking parts, narrators, costume helpers, set designers (simple backdrops).</p>
                     <p><strong>Learning Demonstrated:</strong> Understanding of Bible narrative, character roles, cooperation, public speaking (simple).</p>
                 </div>
-                <div class="project-idea w3-panel w3-leftbar w3-border-green w3-hover-shadow">
+                <div class="project-idea w3-panel w3-leftbar w3-border-red w3-hover-shadow"> <!-- Changed border color to theme -->
                     <h4>2. "Our Book of Christian Values" / "Bible Heroes Book":</h4>
                     <p><strong>Description:</strong> Each child contributes a page to a class book. Each page could focus on a specific Christian value (e.g., kindness, with a drawing and a sentence) or a Bible hero they learned about.</p>
                     <p><strong>Learning Demonstrated:</strong> Understanding of values/Bible characters, writing, drawing, summarizing information.</p>
                 </div>
-                <div class="project-idea w3-panel w3-leftbar w3-border-orange w3-hover-shadow">
+                <div class="project-idea w3-panel w3-leftbar w3-border-red w3-hover-shadow"> <!-- Changed border color to theme -->
                     <h4>3. Creation Mural or Diorama Series:</h4>
                     <p><strong>Description:</strong> The class (or small groups) creates a large mural or a series of dioramas depicting the days of Creation, or other key Bible scenes (e.g., Nativity, Noah's Ark).</p>
                     <p><strong>Learning Demonstrated:</strong> Understanding of Creation story/Bible narratives, artistic expression, teamwork.</p>
                 </div>
             </div>
             <div class="w3-half">
-                <div class="project-idea w3-panel w3-leftbar w3-border-red w3-hover-shadow">
+                <div class="project-idea w3-panel w3-leftbar w3-border-red w3-hover-shadow"> <!-- Changed border color to theme -->
                     <h4>4. "Service Fair" or "Kindness Project Showcase":</h4>
                     <p><strong>Description:</strong> If the class has engaged in small service projects or acts of kindness, they can present what they did and what they learned. This could be through posters, short talks, or showing items they created for others.</p>
                     <p><strong>Learning Demonstrated:</strong> Application of Christian values, empathy, communication skills.</p>
                 </div>
-                <div class="project-idea w3-panel w3-leftbar w3-border-purple w3-hover-shadow">
+                <div class="project-idea w3-panel w3-leftbar w3-border-red w3-hover-shadow"> <!-- Changed border color to theme -->
                     <h4>5. Hymn/Song Performance with Artwork:</h4>
                     <p><strong>Description:</strong> Children learn and perform a selection of hymns or Christian songs learned throughout the year. They can also create artwork to be displayed during their performance, illustrating the themes of the songs.</p>
                     <p><strong>Learning Demonstrated:</strong> Memorization of songs, understanding of lyrical themes, artistic expression, performance.</p>
                 </div>
-                <div class="project-idea w3-panel w3-leftbar w3-border-deep-purple w3-hover-shadow">
+                <div class="project-idea w3-panel w3-leftbar w3-border-red w3-hover-shadow"> <!-- Changed border color to theme -->
                     <h4>6. "What I've Learned About God" Sharing Circle:</h4>
                     <p><strong>Description:</strong> A more reflective project where each child prepares to share one or two important things they've learned about God, Jesus, or the Bible during the year. This could be accompanied by a drawing or a symbol they create.</p>
                     <p><strong>Learning Demonstrated:</strong> Personal reflection, ability to articulate faith concepts in simple terms.</p>
@@ -71,7 +84,7 @@
     <hr>
 
     <div class="w3-card-4 w3-margin w3-padding">
-        <h2 class="w3-text-green w3-border-bottom">Planning Template for Chosen Project:</h2>
+        <h2 class="section-heading">Planning Template for Chosen Project:</h2>
 
         <p><strong>Chosen Project Title:</strong> <span class="editable">_________________________________________________</span></p>
 
@@ -88,11 +101,11 @@
             <li><span class="editable">Objective 3</span></li>
         </ol>
 
-        <h3 class="w3-text-dark-grey">Timeline & Steps:</h3>
+        <h3 class="subsection-heading">Timeline & Steps:</h3>
         <div class="w3-responsive">
             <table class="w3-table-all w3-hoverable">
                 <thead>
-                    <tr class="w3-light-green">
+                    <tr> <!-- Removed w3-light-green, th style is now global -->
                         <th>Week/Session</th>
                         <th>Task/Focus</th>
                         <th>Materials/Resources Needed</th>

--- a/church_school_lesson_plan/assessments/grading_and_feedback_philosophy.html
+++ b/church_school_lesson_plan/assessments/grading_and_feedback_philosophy.html
@@ -6,26 +6,35 @@
     <title>Grading and Feedback Philosophy (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; line-height: 1.6; }
         .w3-container h1, .w3-container h2, .w3-container h3 { font-weight: 400; }
-        .emphasis { color: #0066cc; font-weight: bold; } /* W3.CSS teal is #009688 */
-        .highlight-panel { background-color: #f0f8ff; border-left: 5px solid #009688; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .section-card h2, .section-card h3 { color: var(--theme-color-main); }
+        .emphasis { color: var(--theme-color-dark-accent); font-weight: bold; }
+        .highlight-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-dark-accent); }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Grading and Feedback Philosophy</h1>
         <p>(Focus: 6-7 Year Olds in a Church School Setting)</p>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding-16 w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding-16 w3-margin-top w3-card">
         <p>This document outlines a recommended philosophy for assessment, grading, and feedback for young children (6-7 years old) in a church school environment. The primary goal is to <span class="emphasis">nurture their faith, encourage participation, and foster a love for learning</span>, rather than focusing on rigorous academic scoring.</p>
     </div>
 
-    <div class="w3-card w3-margin-top w3-padding">
-        <h2 class="w3-text-teal">Core Principles</h2>
+    <div class="w3-card w3-margin-top w3-padding section-card">
+        <h2>Core Principles</h2>
         <ul class="w3-ul w3-hoverable">
             <li><strong>Encouragement over Criticism:</strong> Feedback should always be positive and encouraging, focusing on effort and growth.</li>
             <li><strong>Process over Product:</strong> Value the child's learning journey, participation, and effort more than the perfection of the final product.</li>
@@ -36,8 +45,8 @@
         </ul>
     </div>
 
-    <div class="w3-card w3-margin-top w3-padding">
-        <h2 class="w3-text-teal">What "Grading" Might Look Like</h2>
+    <div class="w3-card w3-margin-top w3-padding section-card">
+        <h2>What "Grading" Might Look Like</h2>
         <p>Formal letter grades (A, B, C) are generally not recommended for this age group in this context. Instead, consider:</p>
         <ul class="w3-ul">
             <li><strong>Completion & Participation:</strong> Acknowledging that a child has completed an activity or participated earnestly.

--- a/church_school_lesson_plan/assessments/midterm_review_ideas.html
+++ b/church_school_lesson_plan/assessments/midterm_review_ideas.html
@@ -6,21 +6,34 @@
     <title>Midterm Review Ideas & Checklist (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 100px; display: inline-block; }
         .section { margin-bottom: 20px; }
         .checklist-item { margin-bottom: 5px; }
         .w3-ul li { padding-bottom: 8px; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .section-card h2 { color: var(--theme-color-main); border-bottom: 2px solid var(--theme-color-main); padding-bottom: 5px; }
+        .checklist-panel { background-color: var(--theme-color-light-accent); border-left: 4px solid var(--theme-color-dark-accent); }
+        .follow-up-panel { background-color: #fff8e1; border-left: 5px solid #ffc107; } /* Amber for follow-up */
+        .follow-up-panel h3 { color: #e65100; } /* Darker Amber */
+
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Midterm Review Ideas & Checklist (6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card">
         <p><strong>Purpose:</strong> To review key concepts, stories, and values covered in the first half of the term/semester in an engaging and non-stressful way. This is more about reinforcing learning and identifying areas for re-teaching than formal testing.</p>
         <p><strong>Subject(s) Covered:</strong> <span class="editable">_______________________________________</span></p>
         <p><strong>Review Period:</strong> <span class="editable">(e.g., Week of [Date])</span></p>
@@ -28,8 +41,8 @@
 
     <hr>
 
-    <div class="section w3-card w3-padding">
-        <h2 class="w3-text-blue w3-border-bottom">Possible Review Activities:</h2>
+    <div class="section w3-card w3-padding section-card">
+        <h2>Possible Review Activities:</h2>
         <ol class="w3-ul w3-hoverable">
             <li>
                 <strong>Story Retell Carousel:</strong>

--- a/church_school_lesson_plan/assessments/quiz_template.html
+++ b/church_school_lesson_plan/assessments/quiz_template.html
@@ -6,23 +6,36 @@
     <title>Quiz Template (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 100px; display: inline-block; }
         .quiz-section { margin-bottom: 20px; padding: 15px; border: 1px solid #ddd; }
-        .instructions { font-style: italic; margin-bottom: 10px; }
+        .quiz-section h2 { color: var(--theme-color-dark-accent); }
+        .instructions { font-style: italic; margin-bottom: 10px; color: var(--theme-color-dark-accent); }
         .drawing-space { border: 1px dashed #aaa; min-height: 150px; margin-top: 10px; padding:10px; text-align:center; color: #aaa; }
         .image-placeholder { border: 1px solid #ccc; padding: 20px; text-align: center; margin: 5px; background-color: #f9f9f9; min-width: 100px; min-height: 80px; display: inline-block;}
-        .word-bank { background-color: #e7f3fe; border: 1px solid #b3d7ff; padding: 10px; margin-bottom: 10px; }
+        .word-bank { background-color: var(--theme-color-light-accent); border: 1px solid var(--theme-color-main); padding: 10px; margin-bottom: 10px; color: var(--theme-color-dark-accent); }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .teacher-notes-panel { background-color: #fff8e1; border-left: 5px solid #ffc107; } /* Amber for teacher notes */
+        .teacher-notes-panel h3 { color: #e65100; } /* Darker Amber */
+        .w3-table th { background-color: var(--theme-color-dark-accent) !important; color: var(--text-color-on-main) !important; }
+
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Quiz Template (6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card">
         <p><strong>Subject:</strong> <span class="editable">_________________________</span></p>
         <p><strong>Topic/Unit:</strong> <span class="editable">_________________________</span></p>
         <p><strong>Name:</strong> <span class="editable">_________________________</span></p>
@@ -31,14 +44,14 @@
 
     <hr>
 
-    <div class="w3-panel w3-pale-blue w3-leftbar w3-border-blue w3-padding">
+    <div class="w3-panel info-panel w3-padding">
         <p class="instructions"><strong>Instructions:</strong> Listen carefully to the instructions for each part. Do your best!</p>
     </div>
 
     <hr>
 
     <div class="quiz-section w3-card">
-        <h2 class="w3-text-blue">Part 1: Picture Matching <span class="w3-small w3-text-grey">(Example)</span></h2>
+        <h2>Part 1: Picture Matching <span class="w3-small w3-text-grey">(Example)</span></h2>
         <p class="instructions">Draw a line to match the picture to the correct word or concept.</p>
         <table class="w3-table w3-bordered">
             <thead>

--- a/church_school_lesson_plan/assessments/student_grades_template.html
+++ b/church_school_lesson_plan/assessments/student_grades_template.html
@@ -6,25 +6,39 @@
     <title>Student Grades & Observations Template</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --theme-color-table-header: #a33a3a; /* Medium-dark red for table headers */
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
-        .editable { background-color: #f0f0f0; padding: 4px; border: 1px dotted #ccc; width: 100%; min-height: 30px; display: block; box-sizing: border-box; }
-        .small-editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 50px; display: inline-block; }
-        .w3-table-all th { background-color: #009688; color: white; } /* Teal background for table headers */
+        .editable { background-color: #f0f0f0; padding: 4px; border: 1px dotted #ccc; width: 100%; min-height: 30px; display: block; box-sizing: border-box; margin-bottom: 5px; } /* Added margin-bottom */
+        .small-editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 50px; display: inline-block; margin-bottom: 5px;} /* Added margin-bottom */
+        .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
         .w3-table-all td, .w3-table-all th { vertical-align: top; padding: 8px; }
-        .student-record { margin-bottom: 25px; padding-bottom: 15px; border-bottom: 2px solid #009688; }
+        .student-record { margin-bottom: 25px; padding-bottom: 15px; border-bottom: 2px solid var(--theme-color-main); }
+        .student-record h2 { color: var(--theme-color-main); }
         .notes-area { min-height: 60px; }
-        .section-title { margin-top: 1em; margin-bottom: 0.5em; font-size: 1.2em; font-weight: bold; color: #00796b; } /* Darker Teal */
+        .section-title { margin-top: 1em; margin-bottom: 0.5em; font-size: 1.2em; font-weight: bold; color: var(--theme-color-dark-accent); }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .add-row-button { background-color: var(--theme-color-dark-accent) !important; color: var(--text-color-on-main) !important; }
+        .add-student-button { background-color: var(--theme-color-main) !important; color: var(--text-color-on-main) !important; border-color: var(--theme-color-dark-accent) !important; }
+        .add-student-button:hover { background-color: var(--theme-color-dark-accent) !important; }
+
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Student Grades & Observations Template</h1>
         <p>(For Teacher's Use - Manual Input)</p>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card">
         <p><strong>Term/Semester:</strong> <span class="small-editable">_________________</span> &nbsp;&nbsp;
            <strong>Year:</strong> <span class="small-editable">_________</span> &nbsp;&nbsp;
            <strong>Class/Group:</strong> <span class="small-editable">6-7 Year Olds</span>
@@ -34,7 +48,7 @@
 
     <!-- Repeat this .student-record block for each student -->
     <div class="student-record w3-card-2 w3-padding w3-margin-top">
-        <h2 class="w3-text-teal">Student Name: <span class="editable">_________________________</span></h2>
+        <h2>Student Name: <span class="editable">_________________________</span></h2>
 
         <div class="section-title">Overall Participation & Engagement:</div>
         <span class="editable notes-area">(e.g., Actively participates in discussions, shows enthusiasm, works well with others, needs encouragement to share, etc.)</span>

--- a/church_school_lesson_plan/classroom_management_resources/attendance_sheet_template.html
+++ b/church_school_lesson_plan/classroom_management_resources/attendance_sheet_template.html
@@ -6,29 +6,41 @@
     <title>Attendance Sheet Template</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --theme-color-table-header: #a33a3a; /* Medium-dark red for table headers */
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 80px; display: inline-block; }
-        .w3-table-all th { background-color: #009688; color: white; } /* Teal */
+        .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
         .w3-table-all td, .w3-table-all th { text-align: center; vertical-align: middle; padding: 6px;}
         .student-name-col { text-align: left; min-width: 150px;}
         .date-col { min-width: 80px; }
         .notes-col { min-width: 200px; text-align: left;}
-        .print-button { margin-top:20px; margin-bottom:20px; }
+        .print-button { margin-top:20px; margin-bottom:20px; background-color: var(--theme-color-dark-accent) !important; color: var(--text-color-on-main) !important; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .add-row-button { background-color: var(--theme-color-dark-accent) !important; color: var(--text-color-on-main) !important; }
+
+
         @media print {
             .no-print { display: none; }
-            body { -webkit-print-color-adjust: exact; print-color-adjust: exact; } /* Ensure colors print */
-            .w3-table-all th { background-color: #009688 !important; color: white !important; }
+            body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; -webkit-print-color-adjust: exact; print-color-adjust: exact;}
         }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center no-print">
+    <header class="w3-container main-page-header w3-center no-print">
         <h1>Attendance Sheet Template</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card no-print">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card no-print">
         <p><strong>Class/Group:</strong> <span class="editable">6-7 Year Olds</span></p>
         <p><strong>Month/Term:</strong> <span class="editable">_________________</span> &nbsp;&nbsp;
            <strong>Year:</strong> <span class="editable">_________</span>
@@ -37,7 +49,7 @@
     </div>
 
     <div class="w3-center no-print">
-        <button class="w3-button w3-green print-button" onclick="window.print()">Print Attendance Sheet</button>
+        <button class="w3-button print-button" onclick="window.print()">Print Attendance Sheet</button>
     </div>
 
     <div class="w3-responsive w3-card-4">

--- a/church_school_lesson_plan/classroom_management_resources/emergency_contact_form_template.html
+++ b/church_school_lesson_plan/classroom_management_resources/emergency_contact_form_template.html
@@ -6,36 +6,50 @@
     <title>Emergency Contact Form Template</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .form-section { margin-bottom: 15px; padding: 10px; border: 1px solid #eee; }
-        .form-section h3 { color: #009688; margin-top:0; border-bottom: 1px solid #009688; padding-bottom:5px; } /* Teal */
-        .field-label { font-weight: bold; display: block; margin-bottom: 2px; }
+        .form-section h3 { color: var(--theme-color-dark-accent); margin-top:0; border-bottom: 1px solid var(--theme-color-main); padding-bottom:5px; }
+        .field-label { font-weight: bold; display: block; margin-bottom: 2px; color: var(--theme-color-dark-accent);}
         .editable-field { background-color: #f9f9f9; border: 1px solid #ccc; padding: 6px; width: 100%; box-sizing: border-box; margin-bottom: 8px; min-height: 30px;}
         .small-editable-inline { background-color: #f9f9f9; border-bottom: 1px solid #ccc; padding: 4px; min-width:150px; display:inline-block;}
-        .important-note { background-color: #fff3e0; border-left: 4px solid #ff9800; padding: 10px; margin-top: 15px; } /* W3.CSS Orange */
+        .important-note { background-color: var(--theme-color-light-accent); border-left: 4px solid var(--theme-color-main); padding: 10px; margin-top: 15px; color: var(--theme-color-dark-accent); }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .print-button { background-color: var(--theme-color-dark-accent) !important; color: var(--text-color-on-main) !important;}
+        .form-title { color: var(--theme-color-main); }
+
         @media print {
             .no-print { display: none; }
             body { font-size: 12pt; }
-            .editable-field { border: 1px solid #ccc !important; background-color: #fff !important; } /* Ensure visibility for print */
+            .editable-field { border: 1px solid #ccc !important; background-color: #fff !important; }
             .small-editable-inline { border-bottom: 1px solid #ccc !important; background-color: #fff !important;}
+            .form-section h3 { color: #000 !important; border-bottom-color: #000 !important;}
+            .field-label { color: #000 !important; }
+            .form-title { color: #000 !important; }
         }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center no-print">
+    <header class="w3-container main-page-header w3-center no-print">
         <h1>Emergency Contact & Medical Information Form</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card no-print">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card no-print">
         <p>This form is for collecting essential emergency contact and medical information for each student. Please ensure this information is kept confidential and secure, according to your church's privacy policies.</p>
-        <button class="w3-button w3-green w3-margin-bottom" onclick="window.print()">Print Blank Form</button>
-        <p class="w3-small w3-text-red"><strong>Note:</strong> Teachers would typically print this form for parents to fill out, or fill it in based on information provided by parents. The "editable" fields below are for template viewing or if a teacher is transcribing information digitally.</p>
+        <button class="w3-button print-button w3-margin-bottom" onclick="window.print()">Print Blank Form</button>
+        <p class="w3-small" style="color: var(--theme-color-main);"><strong>Note:</strong> Teachers would typically print this form for parents to fill out, or fill it in based on information provided by parents. The "editable" fields below are for template viewing or if a teacher is transcribing information digitally.</p>
     </div>
 
     <div class="w3-card-4 w3-padding w3-margin-top">
-        <h2 class="w3-center w3-text-teal">Student Information</h2>
+        <h2 class="w3-center form-title">Student Information</h2>
         <div class="form-section">
             <label class="field-label" for="student_name">Full Name of Student:</label>
             <div id="student_name" contenteditable="true" class="editable-field"></div>
@@ -47,7 +61,7 @@
             <div id="class_grade" contenteditable="true" class="editable-field">6-7 Year Olds</div>
         </div>
 
-        <h2 class="w3-center w3-text-teal">Parent/Guardian Information</h2>
+        <h2 class="w3-center form-title">Parent/Guardian Information</h2>
         <div class="form-section">
             <h3>Parent/Guardian 1:</h3>
             <label class="field-label" for="pg1_name">Full Name:</label>

--- a/church_school_lesson_plan/classroom_management_resources/group_management_template.html
+++ b/church_school_lesson_plan/classroom_management_resources/group_management_template.html
@@ -6,45 +6,63 @@
     <title>Group Management Template</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 4px; border: 1px dotted #ccc; width: 100%; min-height: 30px; display: block; box-sizing: border-box; margin-bottom: 5px;}
         .small-editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 80px; display: inline-block; }
         .group-card { margin-bottom: 20px; }
-        .group-header { background-color: #009688; color: white; padding: 10px; } /* Teal */
+        .group-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-main); padding: 10px; }
+        .group-header .small-editable { background-color: var(--theme-color-main); color: var(--text-color-on-main); border-bottom: 1px solid var(--theme-color-light-accent);}
         .student-list li { padding: 5px 0; }
         .notes-area { min-height: 60px; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .print-button { background-color: var(--theme-color-dark-accent) !important; color: var(--text-color-on-main) !important;}
+        .add-group-button { background-color: var(--theme-color-main) !important; color: var(--text-color-on-main) !important;}
+        .add-student-button { background-color: var(--theme-color-light-accent) !important; color: var(--theme-color-dark-accent) !important; border: 1px solid var(--theme-color-dark-accent) !important;}
+        .group-subsection-title { color: var(--theme-color-main); }
+
+
         @media print {
             .no-print { display: none; }
+            .group-header { background-color: #ccc !important; color: #000 !important; -webkit-print-color-adjust: exact; print-color-adjust: exact;}
+            .group-header .small-editable { background-color: #ccc !important; color: #000 !important; border-bottom: 1px solid #000 !important;}
+
         }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center no-print">
+    <header class="w3-container main-page-header w3-center no-print">
         <h1>Group Management Template</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card no-print">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card no-print">
         <p><strong>Activity/Project:</strong> <span class="editable">_________________________</span></p>
         <p><strong>Date(s):</strong> <span class="editable">_________________</span></p>
         <p>Use this template to organize students into groups for projects or activities, and to note roles or observations.</p>
     </div>
 
     <div class="w3-center no-print">
-        <button class="w3-button w3-green w3-margin-bottom" onclick="window.print()">Print Group List</button>
-        <button class="w3-button w3-blue-grey w3-margin-bottom" onclick="addGroupCard()">+ Add Another Group</button>
+        <button class="w3-button print-button w3-margin-bottom" onclick="window.print()">Print Group List</button>
+        <button class="w3-button add-group-button w3-margin-bottom" onclick="addGroupCard()">+ Add Another Group</button>
     </div>
 
     <!-- Repeat this .group-card block for each group -->
     <div class="w3-card-4 group-card">
         <header class="w3-container group-header">
-            <h2>Group Name/Number: <span contenteditable="true" class="small-editable" style="background-color: #00796b; color:white;">Group 1</span></h2>
+            <h2>Group Name/Number: <span contenteditable="true" class="small-editable">Group 1</span></h2>
         </header>
         <div class="w3-container w3-padding">
             <div class="w3-row-padding">
                 <div class="w3-half">
-                    <h4 class="w3-text-teal">Group Members:</h4>
+                    <h4 class="group-subsection-title">Group Members:</h4>
                     <ul class="w3-ul student-list">
                         <li><span class="editable">Student Name A</span></li>
                         <li><span class="editable">Student Name B</span></li>

--- a/church_school_lesson_plan/daily_schedules/sample_daily_schedule_template.html
+++ b/church_school_lesson_plan/daily_schedules/sample_daily_schedule_template.html
@@ -6,20 +6,33 @@
     <title>Sample Daily Schedule Template</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-table-header: #701111; /* Darker red for table headers */
+            --theme-color-section-header: #a33a3a; /* Medium-dark red for section titles */
+            --text-color-on-main: white;
+            --text-color-on-section: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 100px; display: inline-block; }
-        .section-title { margin-top: 20px; margin-bottom: 10px; font-weight: bold; }
-        .w3-table-all th, .w3-table-all td { padding: 8px; }
+        .section-title { margin-top: 20px; margin-bottom: 10px; font-weight: bold; background-color: var(--theme-color-section-header); color: var(--text-color-on-section); padding: 5px 8px; }
+        .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
+        .w3-table-all td { padding: 8px; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); }
+        .notes-panel-header { color: var(--theme-color-dark-accent); font-weight: bold;} /* For h2 in notes panels */
+        .notes-panel {border-left: 5px solid var(--theme-color-table-header); background-color: #fff8f8; }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal">
+    <header class="w3-container main-page-header">
         <h1>Sample Daily Schedule Template (6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top">
+    <div class="w3-panel info-panel w3-padding w3-margin-top">
         <p><strong>Theme/Topic for the Day:</strong> <span class="editable">_________________________</span></p>
         <p><strong>Date:</strong> <span class="editable">_______________</span></p>
     </div>
@@ -29,7 +42,7 @@
     <div class="w3-responsive">
         <table class="w3-table-all w3-hoverable w3-card-4">
             <thead>
-                <tr class="w3-teal">
+                <tr> <!-- Removed w3-teal, th style is now global -->
                     <th>Time Slot</th>
                     <th>Activity/Subject</th>
                     <th>Details/Notes</th>
@@ -37,7 +50,7 @@
             </thead>
             <tbody>
                 <tr>
-                    <td colspan="3" class="section-title w3-blue-grey w3-center">Morning Session (Example: 3 hours)</td>
+                    <td colspan="3" class="section-title w3-center">Morning Session (Example: 3 hours)</td>
                 </tr>
                 <tr>
                     <td>8:00 - 8:15 AM</td>

--- a/church_school_lesson_plan/events_and_awards/annual_events_calendar_template.html
+++ b/church_school_lesson_plan/events_and_awards/annual_events_calendar_template.html
@@ -6,26 +6,41 @@
     <title>Annual Events, Awards & Celebrations Calendar (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --theme-color-table-header: #a33a3a; /* Medium-dark red for table headers */
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 50px; display: inline-block; margin-bottom:3px;}
         .full-width-editable { background-color: #f0f0f0; padding: 4px; border: 1px dotted #ccc; width: 100%; min-height: 30px; display: block; box-sizing: border-box;}
-        .w3-table-all th { background-color: #00796b; color: white; } /* Darker Teal */
+        .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
         .w3-table-all td, .w3-table-all th { vertical-align: top; padding: 8px; }
-        .term-header { background-color: #a0d2db; color: #004d40; padding: 10px; margin-top:20px; font-size: 1.2em; font-weight: bold;} /* Light blue-grey with dark teal text */
+        .term-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-main); padding: 10px; margin-top:20px; font-size: 1.2em; font-weight: bold;}
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .key-panel { background-color: #fff8e1; border: 1px solid #ffdd72; color: #795548;} /* Light Amber with Brown text */
+        .key-panel h4 { color: #c08c0c;} /* Darker Amber for Key title */
+        .notes-panel { background-color: var(--theme-color-light-accent); border-left: 4px solid var(--theme-color-dark-accent); }
+        .notes-panel h4 { color: var(--theme-color-main); }
+        .add-row-button { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
+
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Annual Events, Awards & Celebrations Calendar Template (6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card">
         <p><strong>School Year:</strong> <span class="editable">_________________</span></p>
         <p>This template helps plan and track special events, award recognitions, and celebrations throughout the church school year.</p>
-        <div class="w3-panel w3-sand w3-padding">
-            <h4 class="w3-text-brown">Key:</h4>
+        <div class="w3-panel key-panel w3-padding">
+            <h4>Key:</h4>
             <ul class="w3-ul">
                 <li><strong>(E)</strong> = Event (e.g., pageant, party, special service)</li>
                 <li><strong>(A)</strong> = Award/Recognition (e.g., monthly kindness award, end-of-term certificates)</li>

--- a/church_school_lesson_plan/events_and_awards/field_trip_planning_template.html
+++ b/church_school_lesson_plan/events_and_awards/field_trip_planning_template.html
@@ -6,31 +6,44 @@
     <title>Field Trip Planning Template</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; line-height: 1.6; }
         .w3-container h1, .w3-container h2, .w3-container h3 { font-weight: 400; }
         .editable { background-color: #f0f0f0; padding: 4px; border: 1px dotted #ccc; width: 100%; min-height: 30px; display: block; box-sizing: border-box; margin-bottom: 8px;}
         .small-editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 100px; display: inline-block; margin-bottom: 5px;}
         .section-card { margin-top: 20px; }
-        .section-header { background-color: #00796b; color: white; padding:8px 16px; } /* Darker Teal */
-        .subsection-title { font-weight: bold; margin-top: 10px; color: #004d40; } /* Darkest Teal */
+        .section-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-main); padding:8px 16px; }
+        .subsection-title { font-weight: bold; margin-top: 10px; color: var(--theme-color-main); }
         .checkbox-item label { margin-left: 5px; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .print-button { background-color: var(--theme-color-dark-accent) !important; color: var(--text-color-on-main) !important;}
+        .page-footer { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+
+
          @media print {
             .no-print { display: none; }
             .editable { border: 1px solid #ccc !important; background-color: #fff !important; }
             .small-editable { border-bottom: 1px solid #ccc !important; background-color: #fff !important;}
-        }
+            .section-header { background-color: #ccc !important; color: #000 !important; -webkit-print-color-adjust: exact; print-color-adjust: exact;}
+         }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center no-print">
+    <header class="w3-container main-page-header w3-center no-print">
         <h1>Class Field Trip Planning Template</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card no-print">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card no-print">
         <p>This template is designed to help plan and organize a class field trip for 6-7 year old students. Fill in all relevant sections to ensure a smooth, educational, and enjoyable experience.</p>
-        <button class="w3-button w3-green w3-margin-bottom" onclick="window.print()">Print Field Trip Plan</button>
+        <button class="w3-button print-button w3-margin-bottom" onclick="window.print()">Print Field Trip Plan</button>
     </div>
 
     <!-- Basic Information -->

--- a/church_school_lesson_plan/events_and_awards/weekly_prize_system.html
+++ b/church_school_lesson_plan/events_and_awards/weekly_prize_system.html
@@ -6,26 +6,37 @@
     <title>Optional Weekly Prize System Guide</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; line-height: 1.6; }
         .w3-container h1, .w3-container h2, .w3-container h3 { font-weight: 400; }
-        .highlight-panel { background-color: #fff8e1; border-left: 5px solid #ffc107; } /* W3.CSS amber */
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .section-card h2 { color: var(--theme-color-main); }
+        .highlight-panel { background-color: var(--theme-color-light-accent); border-left: 4px solid var(--theme-color-dark-accent); } /* Themed highlight */
+        .highlight-panel h4 { color: var(--theme-color-dark-accent); }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 100px; display: inline-block; }
-        .important-note { color: #d32f2f; font-weight: bold; } /* W3.CSS red */
+        .important-note { color: var(--theme-color-main); font-weight: bold; } /* Themed important note */
+        .page-footer { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-amber w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Optional Weekly Prize System Guide (6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding-16 w3-margin-top w3-card">
-        <p>This document provides ideas and considerations for implementing an <span class="w3-text-red w3-large">optional</span> weekly random prize winner system for a 6-7 year old church school class. The primary aim should be to add a little fun and positive anticipation, not to create competition or feelings of exclusion.</p>
+    <div class="w3-panel info-panel w3-padding-16 w3-margin-top w3-card">
+        <p>This document provides ideas and considerations for implementing an <span class="important-note w3-large">optional</span> weekly random prize winner system for a 6-7 year old church school class. The primary aim should be to add a little fun and positive anticipation, not to create competition or feelings of exclusion.</p>
     </div>
 
-    <div class="w3-card w3-margin-top w3-padding">
-        <h2 class="w3-text-amber">Core Philosophy</h2>
+    <div class="w3-card w3-margin-top w3-padding section-card">
+        <h2>Core Philosophy</h2>
         <ul class="w3-ul w3-hoverable">
             <li><strong>Fun & Encouragement:</strong> The system should be light-hearted and seen as a bonus, not a primary motivator for good behavior or learning (these should be intrinsic or encouraged through other means).</li>
             <li><strong>Fairness & Inclusivity:</strong> If implementing, ensure the selection process is genuinely random and that, over time, all children have opportunities.</li>

--- a/church_school_lesson_plan/homework_optional/homework_classwork_ideas.html
+++ b/church_school_lesson_plan/homework_optional/homework_classwork_ideas.html
@@ -6,22 +6,35 @@
     <title>Optional Homework & Classwork Ideas (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; line-height: 1.6; }
         .w3-container h1, .w3-container h2, .w3-container h3 { font-weight: 400; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
         .section-card { margin-top: 20px; }
+        .section-card-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-main); }
+        .section-card-header.light { background-color: var(--theme-color-light-accent); color: var(--theme-color-dark-accent); border-bottom: 2px solid var(--theme-color-main); }
         .idea-list li { padding-bottom: 8px; }
-        .guiding-principles { background-color: #e8f5e9; border-left: 5px solid #4caf50; } /* W3.CSS green */
+        .guiding-principles { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .guiding-principles h2 { color: var(--theme-color-main); }
+        .subsection-title { color: var(--theme-color-dark-accent); }
+        .notes-panel { background-color: #fff8e1; border-left: 5px solid #ffc107; } /* Amber for notes panel */
+        .notes-panel h3 { color: #e65100; } /* Darker Amber */
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-green w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Optional Homework & Classwork Ideas (6-7 Year Olds)</h1>
     </header>
 
     <div class="w3-panel w3-padding-16 w3-margin-top guiding-principles w3-card">
-        <h2 class="w3-text-green">Guiding Principles for Optional Homework & Classwork:</h2>
+        <h2>Guiding Principles for Optional Homework & Classwork:</h2>
         <ul class="w3-ul">
             <li><strong>Reinforce, Don't Introduce:</strong> Activities should reinforce concepts already taught in class.</li>
             <li><strong>Age-Appropriate:</strong> Tasks should be manageable for a 6-7 year old with minimal adult help.</li>

--- a/church_school_lesson_plan/index.html
+++ b/church_school_lesson_plan/index.html
@@ -6,17 +6,27 @@
     <title>Church School Lesson Plan Hub (Ages 6-7)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1; /* Lighter shade for hover/accents */
+            --theme-color-dark-accent: #701111; /* Darker shade for contrast or text */
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; background-color: #f4f4f4; }
-        .w3-container h1 { font-weight: 400; }
-        .main-header { background-color: #00796b; color: white; } /* Darker Teal */
+        .w3-container h1, .w3-container h2, .w3-container h3 { font-weight: 400; }
+        .main-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
         .nav-card { margin-top: 16px; margin-bottom: 16px; }
-        .nav-card-header { background-color: #009688; color: white; } /* Teal */
+        .nav-card-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
         .nav-list li { border-bottom: 1px solid #eee; }
-        .nav-list li a { display: block; padding: 10px 15px; text-decoration: none; }
-        .nav-list li a:hover { background-color: #e0f2f1; } /* Light Teal hover */
+        .nav-list li a { display: block; padding: 10px 15px; text-decoration: none; color: #333; }
+        .nav-list li a:hover { background-color: var(--theme-color-light-accent); color: var(--theme-color-dark-accent); }
         .nav-list li a .w3-small { color: #555; display:block; margin-top:3px;}
         .footer { background-color: #333; color: white; padding: 20px 0; margin-top: 30px;}
-        .welcome-panel { background-color: #e0f2f1; border-left: 5px solid #009688; padding: 16px; }
+        .welcome-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); padding: 16px; color: var(--theme-color-dark-accent); }
+        .welcome-panel h2 { color: var(--theme-color-main); }
+        .welcome-panel a { color: var(--theme-color-dark-accent); font-weight:bold; }
+        .welcome-panel a:hover { color: var(--theme-color-main); }
+
     </style>
 </head>
 <body>
@@ -30,7 +40,7 @@
 
     <div class="w3-panel welcome-panel w3-card">
         <h2>Welcome, Teacher!</h2>
-        <p>This hub provides quick access to all the planning templates and resources for our 6-7 year old church school class. Remember to consult the <a href="AGENTS.md" class="w3-text-teal w3-hover-text-dark-grey"><strong>AGENTS.md</strong></a> file for detailed guidance on using and adapting these materials for your specific class needs and for each unique school year.</p>
+        <p>This hub provides quick access to all the planning templates and resources for our 6-7 year old church school class. Remember to consult the <a href="AGENTS.md"><strong>AGENTS.md</strong></a> file for detailed guidance on using and adapting these materials for your specific class needs and for each unique school year.</p>
     </div>
 
     <div class="w3-row-padding">
@@ -116,6 +126,20 @@
                 </header>
                 <ul class="w3-ul nav-list w3-hoverable">
                     <li><a href="story_resources/the_little_helping_seed.html">The Little Helping Seed <span class="w3-small">A story about kindness.</span></a></li>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Lesson Calendars -->
+        <div class="w3-col l4 m6 s12">
+            <div class="w3-card-4 nav-card">
+                <header class="w3-container nav-card-header">
+                    <h3><i class="w3-margin-right"></i>Lesson Calendars</h3>
+                </header>
+                <ul class="w3-ul nav-list w3-hoverable">
+                    <li><a href="lesson_calendars/yearly_overview_template.html">Yearly Overview Template <span class="w3-small">High-level annual planning.</span></a></li>
+                    <li><a href="lesson_calendars/monthly_calendar_template.html">Monthly Calendar Template <span class="w3-small">Grid view for monthly lesson organization.</span></a></li>
+                    <li><a href="lesson_calendars/weekly_calendar_template.html">Weekly Calendar Template <span class="w3-small">Detailed 7-day lesson snapshot.</span></a></li>
                 </ul>
             </div>
         </div>

--- a/church_school_lesson_plan/lesson_calendars/monthly_calendar_template.html
+++ b/church_school_lesson_plan/lesson_calendars/monthly_calendar_template.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Monthly Calendar Template</title>
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+    <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+            --text-color-on-light: #333;
+            --day-cell-height: 120px; /* Adjustable height for day cells */
+            --day-header-bg: #f0f0f0; /* Light grey for day names */
+        }
+        body { font-family: sans-serif; background-color: #fff9f9; } /* Very light red background */
+        .calendar-container { max-width: 1200px; margin: auto; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .calendar-header { text-align: center; padding: 10px 0; }
+        .calendar-header h2 { color: var(--theme-color-dark-accent); margin: 5px 0; }
+        .calendar-header .nav-arrow { text-decoration: none; color: var(--theme-color-main); font-weight: bold; padding: 0 15px; }
+        .calendar-table { width: 100%; border-collapse: collapse; }
+        .calendar-table th, .calendar-table td {
+            border: 1px solid var(--theme-color-light-accent);
+            text-align: left;
+            vertical-align: top;
+            padding: 5px;
+        }
+        .calendar-table th { /* Day names: Sun, Mon, etc. */
+            background-color: var(--day-header-bg);
+            color: var(--theme-color-dark-accent);
+            height: 40px;
+            text-align: center;
+        }
+        .calendar-table td {
+            height: var(--day-cell-height);
+            position: relative; /* For day number positioning */
+        }
+        .day-number {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            font-size: 0.9em;
+            color: var(--theme-color-dark-accent);
+        }
+        .other-month .day-number { color: #bbb; } /* Dim numbers for days not in current month */
+        .other-month { background-color: #fdf5f5; } /* Slightly different bg for other month days */
+        .lesson-title { font-weight: bold; font-size: 0.9em; color: var(--theme-color-main); margin-bottom: 3px; display: block; }
+        .lesson-link { font-size: 0.8em; display: block; margin-bottom: 3px; }
+        .event-note { font-size: 0.8em; color: #555; font-style: italic; }
+        .editable-area {
+            background-color: #fff;
+            border: none;
+            width: 100%;
+            height: calc(var(--day-cell-height) - 25px); /* Adjust based on padding and day number */
+            padding: 3px;
+            box-sizing: border-box;
+            resize: none; /* Prevent manual resize */
+            font-size: 0.85em;
+            color: #333;
+        }
+        .editable-area:focus { outline: 1px solid var(--theme-color-main); background-color: #fff;}
+
+        @media print {
+            body { background-color: #fff; font-size: 10pt; -webkit-print-color-adjust: exact; print-color-adjust: exact;}
+            .no-print { display: none; }
+            .calendar-table th { background-color: var(--day-header-bg) !important; color: #000 !important; }
+            .calendar-table td, .calendar-table th { border: 1px solid #ccc !important; }
+            .other-month { background-color: #f0f0f0 !important; }
+            .lesson-title { color: #000 !important; }
+            .editable-area { background-color: #fff !important; border: none !important; height: auto; }
+            .page-header { display: none; }
+            @page { size: landscape; margin: 0.5in; }
+        }
+    </style>
+</head>
+<body>
+
+<div class="w3-container">
+    <header class="w3-container main-page-header w3-center no-print">
+        <h1>Monthly Lesson Calendar</h1>
+    </header>
+
+    <div class="calendar-container w3-card-4 w3-margin-top" style="background-color: white;">
+        <div class="calendar-header w3-padding">
+            <!-- Mrs. Scott will manually change Month and Year -->
+            <a href="#" class="nav-arrow no-print">&laquo; Previous Month</a>
+            <h2 style="display:inline-block; margin:0 20px;"><span contenteditable="true">Month</span> <span contenteditable="true">Year</span></h2>
+            <a href="#" class="nav-arrow no-print">Next Month &raquo;</a>
+        </div>
+
+        <table class="calendar-table">
+            <thead>
+                <tr>
+                    <th>Sun</th>
+                    <th>Mon</th>
+                    <th>Tue</th>
+                    <th>Wed</th>
+                    <th>Thu</th>
+                    <th>Fri</th>
+                    <th>Sat</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Generate 5 or 6 rows for a typical month -->
+                <!-- Week 1 -->
+                <tr>
+                    <td class="other-month"><span class="day-number">28</span><textarea class="editable-area" placeholder="Notes..."></textarea></td>
+                    <td class="other-month"><span class="day-number">29</span><textarea class="editable-area" placeholder="Notes..."></textarea></td>
+                    <td class="other-month"><span class="day-number">30</span><textarea class="editable-area" placeholder="Notes..."></textarea></td>
+                    <td><span class="day-number">1</span><textarea class="editable-area" placeholder="Lesson Title/Summary&#10;Link: [path/to/plan.html]&#10;Event: Holiday"></textarea></td>
+                    <td><span class="day-number">2</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">3</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">4</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                </tr>
+                <!-- Week 2 -->
+                <tr>
+                    <td><span class="day-number">5</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">6</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">7</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">8</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">9</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">10</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">11</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                </tr>
+                <!-- Week 3 -->
+                <tr>
+                    <td><span class="day-number">12</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">13</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">14</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">15</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">16</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">17</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">18</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                </tr>
+                <!-- Week 4 -->
+                <tr>
+                    <td><span class="day-number">19</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">20</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">21</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">22</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">23</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">24</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">25</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                </tr>
+                <!-- Week 5 (Potentially) -->
+                <tr>
+                    <td><span class="day-number">26</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">27</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">28</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">29</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td><span class="day-number">30</span><textarea class="editable-area" placeholder="Lesson Title/Summary..."></textarea></td>
+                    <td class="other-month"><span class="day-number">1</span><textarea class="editable-area" placeholder="Notes..."></textarea></td>
+                    <td class="other-month"><span class="day-number">2</span><textarea class="editable-area" placeholder="Notes..."></textarea></td>
+                </tr>
+                <!-- Week 6 (If needed for some month layouts) -->
+                 <tr>
+                    <td class="other-month"><span class="day-number"></span><textarea class="editable-area" placeholder=""></textarea></td>
+                    <td class="other-month"><span class="day-number"></span><textarea class="editable-area" placeholder=""></textarea></td>
+                    <td class="other-month"><span class="day-number"></span><textarea class="editable-area" placeholder=""></textarea></td>
+                    <td class="other-month"><span class="day-number"></span><textarea class="editable-area" placeholder=""></textarea></td>
+                    <td class="other-month"><span class="day-number"></span><textarea class="editable-area" placeholder=""></textarea></td>
+                    <td class="other-month"><span class="day-number"></span><textarea class="editable-area" placeholder=""></textarea></td>
+                    <td class="other-month"><span class="day-number"></span><textarea class="editable-area" placeholder=""></textarea></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <footer class="w3-container w3-center w3-margin-top no-print" style="padding: 10px 0;">
+        <p class="w3-small">To use: Save a copy of this template (e.g., "September_2024_Calendar.html"), then edit the Month/Year and day cell contents. Add links to your detailed daily lesson plans.</p>
+    </footer>
+</div>
+
+</body>
+</html>

--- a/church_school_lesson_plan/lesson_calendars/yearly_overview_template.html
+++ b/church_school_lesson_plan/lesson_calendars/yearly_overview_template.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Yearly Overview Template</title>
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+    <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+            --table-header-bg: #ececec; /* Light grey for month headers */
+        }
+        body { font-family: sans-serif; background-color: #fff9f9; }
+        .main-container { max-width: 1200px; margin: auto; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .year-header { text-align: center; padding: 10px 0; }
+        .year-header h2 { color: var(--theme-color-dark-accent); margin: 5px 0; }
+
+        .term-card { margin-bottom: 25px; }
+        .term-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-main); padding: 10px; font-size: 1.3em;}
+
+        .month-table { width: 100%; border-collapse: collapse; margin-top: 0px;}
+        .month-table th, .month-table td {
+            border: 1px solid var(--theme-color-light-accent);
+            padding: 8px;
+            text-align: left;
+            vertical-align: top;
+        }
+        .month-table th { /* Month Name */
+            background-color: var(--table-header-bg);
+            color: var(--theme-color-dark-accent);
+            font-weight: bold;
+            width: 120px; /* Fixed width for month name */
+        }
+        .month-table td ul { list-style-type: disc; margin-left:20px; padding-left:0;}
+        .month-table td li { margin-bottom: 3px;}
+
+        .editable-area {
+            background-color: #f7f7f7;
+            border: 1px dotted #ccc;
+            width: 100%;
+            min-height: 30px;
+            padding: 5px;
+            box-sizing: border-box;
+            font-size: 0.9em;
+            color: #333;
+            margin-top: 2px;
+            display: block;
+        }
+         .editable-inline { background-color: #f7f7f7; border-bottom: 1px dotted #ccc; padding: 2px 4px; display: inline-block;}
+
+
+        @media print {
+            body { background-color: #fff; font-size: 10pt; -webkit-print-color-adjust: exact; print-color-adjust: exact;}
+            .no-print { display: none; }
+            .term-header { background-color: #ccc !important; color: #000 !important; }
+            .month-table th { background-color: #e0e0e0 !important; color: #000 !important; }
+            .month-table td, .month-table th { border: 1px solid #bbb !important; }
+            .editable-area, .editable-inline { background-color: #fff !important; border: 1px dotted #ccc !important; }
+            .main-page-header { display:none; }
+            @page { size: A4 portrait; margin: 0.75in; }
+        }
+    </style>
+</head>
+<body>
+
+<div class="w3-container">
+    <header class="w3-container main-page-header w3-center no-print">
+        <h1>Yearly Lesson Overview</h1>
+    </header>
+
+    <div class="main-container w3-card-4 w3-margin-top" style="background-color: white;">
+        <div class="year-header w3-padding">
+            <h2>School Year: <span class="editable-inline" contenteditable="true">YYYY - YYYY</span></h2>
+        </div>
+
+        <!-- Term 1 Card -->
+        <div class="term-card">
+            <header class="w3-container term-header">
+                <h3>Term 1: <span class="editable-inline" contenteditable="true" style="background-color: var(--theme-color-main); color:white;">e.g., Fall (September - December)</span></h3>
+            </header>
+            <table class="month-table">
+                <tr><th>Month</th><th>Overall Theme(s)</th><th>Major Bible Stories/Units</th><th>Key Values Focus</th><th>Holidays/Events</th><th>Link to Monthly Calendar</th></tr>
+                <tr>
+                    <th>September</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., God's Creation"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Creation Week&#10;- Adam & Eve&#10;- Noah's Ark"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Stewardship&#10;- Obedience"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Welcome Back Sunday"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Sept_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>October</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Patriarchs & God's Promises"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Abraham&#10;- Joseph"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Faith&#10;- Forgiveness"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Harvest Festival"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Oct_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>November</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Moses & Deliverance / Advent Begins"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Baby Moses&#10;- Burning Bush&#10;- Plagues (simplified)&#10;- Advent Theme: Hope"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Courage&#10;- God's Power&#10;- Hope"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Thanksgiving Service"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Nov_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>December</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Advent & Christmas"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Advent Themes: Peace, Joy, Love&#10;- Birth of Jesus (Nativity)"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Peace&#10;- Joy&#10;- Love"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Christmas Pageant&#10;- Class Party"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Dec_Calendar.html]"></span></td>
+                </tr>
+            </table>
+        </div>
+
+        <!-- Term 2 Card -->
+        <div class="term-card">
+            <header class="w3-container term-header">
+                <h3>Term 2: <span class="editable-inline" contenteditable="true" style="background-color: var(--theme-color-main); color:white;">e.g., Winter/Spring (January - May)</span></h3>
+            </header>
+            <table class="month-table">
+                <tr><th>Month</th><th>Overall Theme(s)</th><th>Major Bible Stories/Units</th><th>Key Values Focus</th><th>Holidays/Events</th><th>Link to Monthly Calendar</th></tr>
+                <tr>
+                    <th>January</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Jesus's Early Life & Ministry"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Jesus as a Boy&#10;- Calling Disciples&#10;- First Miracles"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Listening to God&#10;- Following Jesus"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- New Year Blessings"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Jan_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>February</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Jesus Teaches"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Parables (Good Samaritan, Prodigal Son)&#10;- Sermon on the Mount (simplified)"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Love for Neighbors&#10;- Forgiveness"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Valentine's - God's Love"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Feb_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>March</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Journey to the Cross (Lent)"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Jesus's Miracles (Healing)&#10;- Last Supper (simplified)&#10;- Events of Holy Week (age-appropriate)"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Sacrifice&#10;- Remembrance"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Lent Activities"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Mar_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>April</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Easter & New Life"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Resurrection Story&#10;- Jesus Appears to Disciples&#10;- Pentecost (simplified)"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- New Life in Christ&#10;- Joy&#10;- The Holy Spirit"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Easter Celebration"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Apr_Calendar.html]"></span></td>
+                </tr>
+                 <tr>
+                    <th>May</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Living as God's Children / Year Review"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Early Church Stories (simplified)&#10;- Review Favorite Stories/Verses"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- Being Part of God's Family&#10;- Sharing Faith"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- End of Year Program"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to May_Calendar.html]"></span></td>
+                </tr>
+            </table>
+        </div>
+
+        <!-- Summer Term Card (Optional) -->
+        <div class="term-card">
+            <header class="w3-container term-header">
+                 <h3>Summer Term (Optional): <span class="editable-inline" contenteditable="true" style="background-color: var(--theme-color-main); color:white;">e.g., June - August</span></h3>
+            </header>
+            <table class="month-table">
+                <tr><th>Month</th><th>Overall Theme(s)</th><th>Major Bible Stories/Units</th><th>Key Values Focus</th><th>Holidays/Events</th><th>Link to Monthly Calendar</th></tr>
+                <tr>
+                    <th>June</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., VBS Theme or Fun Bible Heroes"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="- VBS"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Jun_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>July</th>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Jul_Calendar.html]"></span></td>
+                </tr>
+                <tr>
+                    <th>August</th>
+                    <td><span class="editable-area" contenteditable="true" placeholder="e.g., Getting Ready for Next Year"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true"></span></td>
+                    <td><span class="editable-area" contenteditable="true" placeholder="[Link to Aug_Calendar.html]"></span></td>
+                </tr>
+            </table>
+        </div>
+    </div>
+    <footer class="w3-container w3-center w3-margin-top no-print" style="padding: 10px 0;">
+        <p class="w3-small">This overview helps map out the entire year. Remember to link to specific monthly calendars once they are populated.</p>
+    </footer>
+</div>
+
+</body>
+</html>

--- a/church_school_lesson_plan/projects/project_outline_template.html
+++ b/church_school_lesson_plan/projects/project_outline_template.html
@@ -6,22 +6,33 @@
     <title>Project Outline Template (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --theme-color-table-header: #a33a3a; /* Medium-dark red for table headers */
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 100px; display: inline-block; margin-bottom: 5px;}
         .full-width-editable { background-color: #f0f0f0; padding: 5px; border: 1px dotted #ccc; width: 100%; min-height: 40px; display: block; margin-bottom:5px; box-sizing: border-box;}
-        .section-header { margin-top: 20px; color: #00796b; } /* Darker Teal */
-        .w3-table-all th, .w3-table-all td { padding: 8px; vertical-align: top;}
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .section-header { margin-top: 20px; color: var(--theme-color-main); border-bottom: 2px solid var(--theme-color-main); padding-bottom: 5px;}
+        .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
+        .w3-table-all td { padding: 8px; vertical-align: top;}
         .w3-card-4 { margin-bottom: 20px; }
+        .notes-panel { border-left: 4px solid var(--theme-color-dark-accent); background-color: var(--theme-color-light-accent); }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Project Outline Template (6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-card-4 w3-light-grey w3-padding w3-margin-top">
+    <div class="w3-card-4 info-panel w3-padding w3-margin-top">
         <p><strong>Project Title:</strong> <span class="editable" style="min-width:300px;">_________________________________________________</span></p>
         <p><strong>Subject(s) Integration:</strong> <span class="editable" style="min-width:300px;">_________________________________________</span><br>
         <span class="w3-small w3-text-grey">(e.g., Bible Story, Arts & Crafts, Community Service)</span></p>
@@ -30,7 +41,7 @@
     </div>
 
     <div class="w3-card-4 w3-padding">
-        <h2 class="section-header w3-border-bottom">1. Project Goal/Big Idea:</h2>
+        <h2 class="section-header">1. Project Goal/Big Idea:</h2>
         <p><strong>What are we trying to make, do, or learn with this project?</strong> (In simple terms for the children)</p>
         <span class="full-width-editable"></span>
         <p><strong>Why is this project important or interesting?</strong> (Connect to faith, values, or learning)</p>
@@ -38,7 +49,7 @@
     </div>
 
     <div class="w3-card-4 w3-padding">
-        <h2 class="section-header w3-border-bottom">2. Learning Objectives for Children:</h2>
+        <h2 class="section-header">2. Learning Objectives for Children:</h2>
         <p>By doing this project, children will:</p>
         <ol class="w3-ul">
             <li><span class="full-width-editable">(e.g., Learn about [Bible Story/Character])</span></li>
@@ -48,12 +59,12 @@
     </div>
 
     <div class="w3-card-4 w3-padding">
-        <h2 class="section-header w3-border-bottom">3. Project Steps/Phases (Simplified for 6-7 year olds):</h2>
-        <p class="w3-panel w3-leftbar w3-sand"><em>(Break down the project into manageable steps. Use simple language. Add more steps if needed.)</em></p>
+        <h2 class="section-header">3. Project Steps/Phases (Simplified for 6-7 year olds):</h2>
+        <p class="w3-panel w3-leftbar notes-panel"><em>(Break down the project into manageable steps. Use simple language. Add more steps if needed.)</em></p>
         <div class="w3-responsive">
             <table class="w3-table-all w3-hoverable">
                 <thead>
-                    <tr class="w3-light-blue">
+                    <tr> <!-- Removed w3-light-blue -->
                         <th>Step #</th>
                         <th>Task Description</th>
                         <th>Key Activities / What Children Will Do</th>

--- a/church_school_lesson_plan/school_year_structure_considerations.html
+++ b/church_school_lesson_plan/school_year_structure_considerations.html
@@ -6,26 +6,38 @@
     <title>School Year Structure Considerations (6-7 Year Olds Church School)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; line-height: 1.6; }
-        .w3-container h1, .w3-container h2, .w3-container h3 { font-weight: 400; }
+        .w3-container h1, .w3-container h2, .w3-container h3, .w3-container h4 { font-weight: 400; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
         .section-card { margin-top: 20px; }
-        .main-point { color: #00796b; font-weight: bold; } /* Darker Teal */
-        .example-box { background-color: #e0f2f1; border-left: 4px solid #00796b; padding: 0.1em 16px; margin-top:10px; margin-bottom:10px;} /* Light teal with dark teal border */
+        .section-card-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-main); }
+        .section-card-header.alt { background-color: var(--theme-color-main); color: var(--text-color-on-main); } /* For the example snippet header */
+        .main-point { color: var(--theme-color-dark-accent); font-weight: bold; }
+        .example-box { background-color: var(--theme-color-light-accent); border-left: 4px solid var(--theme-color-dark-accent); padding: 0.1em 16px; margin-top:10px; margin-bottom:10px;}
+        .example-box h4 { color: var(--theme-color-dark-accent); }
+        .page-footer { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>School Year Structure Considerations (6-7 Year Olds Church School)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding-16 w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding-16 w3-margin-top w3-card">
         <p>Planning the structure of the church school year helps in organizing curriculum delivery, special events, and ensuring a balanced approach to learning. This document outlines key considerations.</p>
     </div>
 
     <div class="w3-card section-card">
-        <header class="w3-container w3-blue-grey">
+        <header class="w3-container section-card-header">
             <h2>1. Dividing the School Year</h2>
         </header>
         <div class="w3-container w3-padding">

--- a/church_school_lesson_plan/story_resources/the_little_helping_seed.html
+++ b/church_school_lesson_plan/story_resources/the_little_helping_seed.html
@@ -6,17 +6,28 @@
     <title>The Little Helping Seed - A Story for Kids</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body {
             font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', sans-serif;
             line-height: 1.8;
-            background-color: #f0fdf4; /* Light green background */
-            color: #386641; /* Dark green text */
+            background-color: #f0fdf4; /* Light green background - Story specific, keep */
+            color: #386641; /* Dark green text - Story specific, keep */
             overflow-x: hidden; /* Prevent horizontal scroll */
         }
         .page-header {
             position: relative; /* For logo positioning */
             padding-bottom: 10px; /* Space if logo is below title */
+            background-color: var(--theme-color-main); /* Themed header background */
+            color: var(--text-color-on-main); /* Themed header text */
         }
+        .page-header h1 { color: var(--text-color-on-main) !important; } /* Ensure h1 in header is themed */
+        .page-header .w3-text-grey { color: var(--theme-color-light-accent) !important; } /* Subtitle color */
+
         .youth-school-logo-container {
             position: absolute;
             top: 10px;
@@ -25,31 +36,36 @@
             height: auto;
             z-index: 10;
         }
+        /* Logo SVG colors are defined inline in its own style block for portability, or can be moved here */
         .youth-school-logo-svg .book-fill { fill: #e3f2fd; }
-        .youth-school-logo-svg .book-stroke { stroke: #00796b; stroke-width:1.5; }
-        .youth-school-logo-svg .sprout-fill { fill: #6a994e; }
-        .youth-school-logo-svg .church-stroke { stroke: #004d40; stroke-width:2; fill:none; }
+        .youth-school-logo-svg .book-stroke { stroke: var(--theme-color-dark-accent); stroke-width:1.5; }
+        .youth-school-logo-svg .sprout-fill { fill: #6a994e; } /* Keep sprout green */
+        .youth-school-logo-svg .church-stroke { stroke: var(--theme-color-dark-accent); stroke-width:2; fill:none; }
 
-        .w3-container h1, .w3-container h2 {
+
+        .story-title-h1 { /* Specific for story title if different from general h1 */
             font-weight: bold;
-            color: #6a994e; /* Medium green for headers */
+            color: var(--text-color-on-main); /* Match header text color */
         }
+        .story-subtitle { color: var(--theme-color-light-accent) !important; }
+
+
         .story-container {
             max-width: 800px;
             margin: auto;
-            position: relative; /* For potential absolute positioned elements within story */
+            position: relative;
         }
         .scene {
             padding: 20px;
             margin-bottom: 30px;
-            background-color: #ffffff;
+            background-color: #ffffff; /* Keep story scenes on white */
             border-radius: 15px;
             box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-            opacity: 0; /* Initially hidden for scroll animation */
-            transform: translateY(30px); /* Initial offset for scroll animation */
-            transition: opacity 1s ease-out, transform 1s ease-out; /* Slightly slower transition */
-            min-height: 280px; /* Ensure scenes have some height, adjusted */
-            overflow: hidden; /* To contain floated elements if any for print */
+            opacity: 0;
+            transform: translateY(30px);
+            transition: opacity 1s ease-out, transform 1s ease-out;
+            min-height: 280px;
+            overflow: hidden;
         }
         .scene.is-visible {
             opacity: 1;

--- a/church_school_lesson_plan/subject_materials/subject_areas_overview.html
+++ b/church_school_lesson_plan/subject_materials/subject_areas_overview.html
@@ -6,27 +6,39 @@
     <title>Subject Areas Overview (6-7 Year Olds)</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --text-color-on-main: white;
+        }
         body { font-family: sans-serif; }
         .subject-card { margin-bottom: 16px; }
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .info-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-main); color: var(--theme-color-dark-accent); }
+        .section-heading { color: var(--theme-color-main); border-bottom: 2px solid var(--theme-color-main); padding-bottom: 5px;}
+        .card-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-main); }
+        .integration-panel { background-color: var(--theme-color-light-accent); border-left: 5px solid var(--theme-color-dark-accent); }
+        .integration-panel h2 { color: var(--theme-color-main); }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Subject Areas Overview (Focus: 6-7 Year Olds)</h1>
     </header>
 
-    <div class="w3-panel w3-light-grey w3-padding w3-margin-top w3-card">
+    <div class="w3-panel info-panel w3-padding w3-margin-top w3-card">
         <p>This document outlines the key subject areas for a church school curriculum designed for children aged 6-7. The goal is to provide a holistic education that integrates faith, foundational academic skills, and personal development.</p>
     </div>
 
-    <h2 class="w3-text-teal w3-border-bottom w3-border-teal">Core Subject Areas:</h2>
+    <h2 class="section-heading">Core Subject Areas:</h2>
 
     <div class="w3-row-padding">
         <div class="w3-col m6 l6 subject-card">
             <div class="w3-card-4">
-                <header class="w3-container w3-blue">
+                <header class="w3-container card-header">
                     <h3>1. Bible Stories & Teachings</h3>
                 </header>
                 <div class="w3-container w3-padding">

--- a/church_school_lesson_plan/subject_materials/subject_unit_template.html
+++ b/church_school_lesson_plan/subject_materials/subject_unit_template.html
@@ -6,21 +6,35 @@
     <title>Subject Unit/Weekly Theme Plan Template</title>
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <style>
+        :root {
+            --theme-color-main: #8C1515; /* Cardinal Red */
+            --theme-color-light-accent: #f8e1e1;
+            --theme-color-dark-accent: #701111;
+            --theme-color-table-header: #a33a3a; /* Medium-dark red for table headers */
+            --text-color-on-main: white;
+            --text-color-on-dark-accent: white;
+        }
         body { font-family: sans-serif; }
         .editable { background-color: #f0f0f0; padding: 2px; border-bottom: 1px dotted #ccc; min-width: 150px; display: inline-block; margin-bottom:5px; }
-        .full-width-editable { background-color: #f0f0f0; padding: 5px; border: 1px dotted #ccc; width: 100%; min-height: 50px; display: block; margin-bottom:5px;}
-        .section-header { margin-top: 20px; }
-        .w3-table-all th, .w3-table-all td { padding: 8px; vertical-align: top;}
+        .full-width-editable { background-color: #f0f0f0; padding: 5px; border: 1px dotted #ccc; width: 100%; min-height: 50px; display: block; margin-bottom:5px; box-sizing: border-box;}
+        .main-page-header { background-color: var(--theme-color-main); color: var(--text-color-on-main); }
+        .section-card-header { background-color: var(--theme-color-dark-accent); color: var(--text-color-on-dark-accent); }
+        .section-card-header h2 { margin-top:0; padding-top:10px; padding-bottom:10px;}
+        .unit-details-form { background-color: var(--theme-color-light-accent); color: var(--theme-color-dark-accent); border-left: 5px solid var(--theme-color-main); }
+        .unit-details-form h2 { color: var(--theme-color-main); }
+        .w3-table-all th { background-color: var(--theme-color-table-header) !important; color: var(--text-color-on-main) !important; }
+        .w3-table-all td { padding: 8px; vertical-align: top;}
+        .info-panel { border-left: 4px solid var(--theme-color-main); background-color: var(--theme-color-light-accent); }
     </style>
 </head>
 <body>
 
 <div class="w3-container">
-    <header class="w3-container w3-teal w3-center">
+    <header class="w3-container main-page-header w3-center">
         <h1>Subject Unit/Weekly Theme Plan Template</h1>
     </header>
 
-    <form class="w3-container w3-card-4 w3-light-grey w3-text-blue w3-margin">
+    <form class="w3-container w3-card-4 unit-details-form w3-margin">
         <h2 class="w3-center">Unit Details</h2>
         <div class="w3-row w3-section">
           <div class="w3-col" style="width:150px"><strong>Subject:</strong></div>
@@ -41,8 +55,8 @@
     </form>
 
     <div class="w3-card-4 w3-margin">
-        <header class="w3-container w3-blue">
-            <h2 class="section-header">1. Overview & Goals</h2>
+        <header class="w3-container section-card-header">
+            <h2>1. Overview & Goals</h2>
         </header>
         <div class="w3-container w3-padding">
             <p><strong>Brief Description of Unit/Theme:</strong></p>
@@ -59,18 +73,18 @@
     </div>
 
     <div class="w3-card-4 w3-margin">
-        <header class="w3-container w3-green">
-            <h2 class="section-header">2. Lesson Breakdown & Activities</h2>
+        <header class="w3-container section-card-header">
+            <h2>2. Lesson Breakdown & Activities</h2>
         </header>
         <div class="w3-container w3-padding">
-            <p class="w3-panel w3-leftbar w3-sand"><em>(Repeat this section for each lesson/session within the unit if applicable)</em></p>
+            <p class="w3-panel w3-leftbar info-panel"><em>(Repeat this section for each lesson/session within the unit if applicable)</em></p>
             <p><strong>Lesson/Session #:</strong> <span class="editable">_______</span></p>
             <p><strong>Topic/Focus:</strong> <span class="editable">_________________________</span></p>
 
             <div class="w3-responsive">
                 <table class="w3-table-all w3-hoverable">
                     <thead>
-                        <tr class="w3-light-green">
+                        <tr> <!-- Removed w3-light-green, th style is now global -->
                             <th>Time Allotment</th>
                             <th>Activity Segment</th>
                             <th>Description of Activity & Teaching Points</th>


### PR DESCRIPTION
This commit introduces several major updates:

1.  **Global Theming:** Applied a new color theme (#8C1515 - Cardinal Red) consistently across all existing HTML templates. This includes headers, accent panels, table headers, and buttons to create a unified visual identity.

2.  **New Calendar Templates:** Added a new `lesson_calendars` directory with three comprehensive templates:
    *   `monthly_calendar_template.html`: A detailed 6-week grid for monthly lesson planning, summaries, and event notes.
    *   `weekly_calendar_template.html`: A 7-day view for more detailed weekly lesson snapshots, including key activities, scripture, and materials.
    *   `yearly_overview_template.html`: A high-level planner for terms/quarters, outlining major themes, units, holidays, and links to monthly views.
    These templates are styled with the new theme and designed for detailed input to meet the 'lengthen source' directive.

3.  **AGENTS.md Update:**
    *   Personalized guidance with references to 'Mrs. Scott'.
    *   Added detailed instructions on how to use the new calendar templates in conjunction with daily lesson plans.

4.  **Index.html Update:**
    *   Added a new 'Lesson Calendars' section to the main menu with links to the new calendar templates.

This work significantly enhances the organizational capabilities and visual coherence of the lesson planning system.