### PR TITLE
feat(link-manager): Add notes, trades slider, and actions modal

### DIFF
--- a/link_manager_app/index.html
+++ b/link_manager_app/index.html
@@ -35,9 +35,14 @@
                         <option value="investing">Investing</option>
                     </select>
                 </div>
+                <div class="form-group">
+                    <label for="notes">Notes:</label>
+                    <textarea id="notes" rows="3"></textarea>
+                </div>
                 <div id="investing-options" class="form-group" style="display: none;">
                     <label for="trades-per-day">Trades per day:</label>
                     <input type="number" id="trades-per-day" min="1" value="1">
+                    <input type="range" id="trades-slider" min="1" max="10" value="1">
                 </div>
                 <input type="hidden" id="editingId">
                 <button type="submit">Add Link</button>
@@ -56,6 +61,18 @@
             <div id="online-section">
                 <h1 class="w3-container w3-orange">Online</h1>
                 <div class="link-list" id="online-links"></div>
+            </div>
+        </div>
+    </div>
+
+    <div id="actions-modal" class="w3-modal">
+        <div class="w3-modal-content">
+            <div class="w3-container">
+                <span onclick="document.getElementById('actions-modal').style.display='none'"
+                      class="w3-button w3-display-topright">&times;</span>
+                <h2>Actions</h2>
+                <button id="modal-edit-btn" class="w3-button w3-blue">Edit</button>
+                <button id="modal-delete-btn" class="w3-button w3-red">Delete</button>
             </div>
         </div>
     </div>

--- a/link_manager_app/js/App.js
+++ b/link_manager_app/js/App.js
@@ -31,12 +31,20 @@ class App {
 
         linkContainers.forEach(container => {
             container.addEventListener('click', (event) => {
-                this.handleLinkItemClick(event);
+                if (event.target.classList.contains('actions-btn')) {
+                    const linkItem = event.target.closest('.link-item');
+                    const linkId = Number(linkItem.getAttribute('data-id'));
+                    this.uiManager.openModal(linkId);
+                }
             });
 
             container.addEventListener('change', (event) => {
                 this.handleToggleClick(event);
             });
+        });
+
+        this.uiManager.modal.addEventListener('click', (event) => {
+            this.handleModalClick(event);
         });
     }
 
@@ -46,7 +54,8 @@ class App {
             const name = document.getElementById('name').value;
             const link = document.getElementById('link').value;
             const section = this.uiManager.sectionSelect.value;
-            const tradesPerDay = document.getElementById('trades-per-day').value;
+            const tradesPerDay = this.uiManager.tradesPerDayInput.value;
+            const notes = this.uiManager.notesInput.value;
 
             if (!name || !link) {
                 NotificationService.showError('Name and link are required.');
@@ -58,7 +67,8 @@ class App {
                 name,
                 link,
                 section,
-                tradesPerDay
+                tradesPerDay,
+                notes
             };
 
             if (editingId) {
@@ -74,19 +84,19 @@ class App {
         }
     }
 
-    handleLinkItemClick(event) {
-        const linkItem = event.target.closest('.link-item');
-        if (!linkItem) return;
+    handleModalClick(event) {
+        const linkId = this.uiManager.currentLinkId;
+        if (!linkId) return;
 
-        const linkId = Number(linkItem.getAttribute('data-id'));
-
-        if (event.target.classList.contains('edit-btn')) {
+        if (event.target.id === 'modal-edit-btn') {
             const link = this.linkManager.getLinkById(linkId);
             if (link) {
                 this.uiManager.populateFormForEdit(link);
+                this.uiManager.closeModal();
             }
-        } else if (event.target.classList.contains('delete-btn')) {
+        } else if (event.target.id === 'modal-delete-btn') {
             this.linkManager.deleteLink(linkId);
+            this.uiManager.closeModal();
         }
     }
 

--- a/link_manager_app/js/Link.js
+++ b/link_manager_app/js/Link.js
@@ -1,5 +1,5 @@
 export class Link {
-    constructor({ id, name, link, section, isEnabled, tradesPerDay, complete, ip }) {
+    constructor({ id, name, link, section, isEnabled, tradesPerDay, complete, ip, notes }) {
         this.id = id || Date.now();
         this.name = name;
         this.link = link;
@@ -7,6 +7,7 @@ export class Link {
         this.isEnabled = isEnabled === undefined ? true : isEnabled;
         this.complete = complete || false;
         this.ip = ip || false;
+        this.notes = notes || '';
         if (this.section === 'investing') {
             this.tradesPerDay = tradesPerDay || 1;
         }

--- a/link_manager_app/js/UIManager.js
+++ b/link_manager_app/js/UIManager.js
@@ -9,6 +9,20 @@ export class UIManager {
         this.editingIdInput = document.getElementById('editingId');
         this.submitButton = this.linkForm.querySelector('button[type="submit"]');
         this.tradesPerDayInput = document.getElementById('trades-per-day');
+        this.tradesSlider = document.getElementById('trades-slider');
+        this.notesInput = document.getElementById('notes');
+        this.modal = document.getElementById('actions-modal');
+        this.currentLinkId = null;
+    }
+
+    openModal(linkId) {
+        this.currentLinkId = linkId;
+        this.modal.style.display = 'block';
+    }
+
+    closeModal() {
+        this.currentLinkId = null;
+        this.modal.style.display = 'none';
     }
 
     renderLinks(links) {
@@ -63,18 +77,26 @@ export class UIManager {
             `;
         }
 
+        let investingInfo = '';
+        if (link.section === 'investing') {
+            investingInfo = `
+                <div class="investing-info">
+                    <span>Trades: ${link.tradesPerDay}</span>
+                    <input type="range" min="1" max="10" value="${link.tradesPerDay}" class="trade-slider" disabled>
+                </div>
+            `;
+        }
+
         linkElement.innerHTML = `
             <div class="link-info">
                 <a href="${link.link}" target="_blank">${link.name}</a>
-                <span class="section-info">
-                    ${link.section === 'investing' ? ` - Trades: ${link.tradesPerDay}` : ''}
-                </span>
+                <p class="notes">${link.notes}</p>
+                ${investingInfo}
             </div>
             <div class="controls">
                 ${toggles}
                 <div class="actions">
-                    <button class="edit-btn">Edit</button>
-                    <button class="delete-btn">Delete</button>
+                    <button class="actions-btn w3-button w3-blue">Actions</button>
                 </div>
             </div>
         `;
@@ -86,6 +108,14 @@ export class UIManager {
             const isInvesting = this.sectionSelect.value === 'investing';
             this.toggleInvestingOptions(isInvesting);
         });
+
+        this.tradesSlider.addEventListener('input', () => {
+            this.tradesPerDayInput.value = this.tradesSlider.value;
+        });
+
+        this.tradesPerDayInput.addEventListener('input', () => {
+            this.tradesSlider.value = this.tradesPerDayInput.value;
+        });
     }
 
     toggleInvestingOptions(show) {
@@ -95,7 +125,9 @@ export class UIManager {
     resetForm() {
         this.linkForm.reset();
         this.editingIdInput.value = '';
+        this.notesInput.value = '';
         this.tradesPerDayInput.value = 1;
+        this.tradesSlider.value = 1;
         this.toggleInvestingOptions(false);
         this.submitButton.textContent = 'Add Link';
     }
@@ -105,11 +137,13 @@ export class UIManager {
         document.getElementById('name').value = link.name;
         document.getElementById('link').value = link.link;
         this.sectionSelect.value = link.section;
+        this.notesInput.value = link.notes;
 
         const isInvesting = link.section === 'investing';
         this.toggleInvestingOptions(isInvesting);
         if (isInvesting) {
-            document.getElementById('trades-per-day').value = link.tradesPerDay;
+            this.tradesPerDayInput.value = link.tradesPerDay;
+            this.tradesSlider.value = link.tradesPerDay;
         }
         this.submitButton.textContent = 'Update Link';
     }


### PR DESCRIPTION
This commit adds several new features to the Link Manager application:
- The ability to add notes to each link.
- A slider to adjust the number of trades per day for investing links.
- A modal for the 'Edit' and 'Delete' actions, which improves the UI by reducing clutter.

The key changes include:
- Updating the `Link` data model to include a `notes` property.
- Adding a `textarea` for notes and a range slider to the form.
- Implementing a modal for link actions.
- Updating the application logic to support these new features.