### PR TITLE
feat(link-manager): Add iframe to display link content

### DIFF
--- a/link_manager_app/index.html
+++ b/link_manager_app/index.html
@@ -63,6 +63,10 @@
                 <div class="link-list" id="online-links"></div>
             </div>
         </div>
+
+        <div id="iframe-container">
+            <iframe id="link-iframe" width="100%" height="500px" style="border:none;"></iframe>
+        </div>
     </div>
 
     <div id="actions-modal" class="w3-modal">

--- a/link_manager_app/js/App.js
+++ b/link_manager_app/js/App.js
@@ -35,6 +35,11 @@ class App {
                     const linkItem = event.target.closest('.link-item');
                     const linkId = Number(linkItem.getAttribute('data-id'));
                     this.uiManager.openModal(linkId);
+                } else if (event.target.tagName === 'A') {
+                    event.preventDefault();
+                    const linkItem = event.target.closest('.link-item');
+                    const linkId = Number(linkItem.getAttribute('data-id'));
+                    this.handleLinkClick(linkId);
                 }
             });
 
@@ -81,6 +86,21 @@ class App {
         } catch (error) {
             NotificationService.showError('An error occurred.');
             console.error(error);
+        }
+    }
+
+    handleLinkClick(linkId) {
+        const link = this.linkManager.getLinkById(linkId);
+        if (link) {
+            switch (link.section) {
+                case 'chat':
+                case 'online':
+                case 'investing':
+                    this.uiManager.loadUrlInIframe(link.link);
+                    break;
+                default:
+                    NotificationService.showError('Unknown section.');
+            }
         }
     }
 

--- a/link_manager_app/js/UIManager.js
+++ b/link_manager_app/js/UIManager.js
@@ -12,7 +12,12 @@ export class UIManager {
         this.tradesSlider = document.getElementById('trades-slider');
         this.notesInput = document.getElementById('notes');
         this.modal = document.getElementById('actions-modal');
+        this.iframe = document.getElementById('link-iframe');
         this.currentLinkId = null;
+    }
+
+    loadUrlInIframe(url) {
+        this.iframe.src = url;
     }
 
     openModal(linkId) {


### PR DESCRIPTION
This commit adds an iframe to the bottom of the page to display the content of the links.

The key changes include:
- Adding an iframe element to the `index.html` file.
- Adding a method to `UIManager.js` to load a URL into the iframe.
- Updating `App.js` to handle link clicks and load the corresponding URL into the iframe.