### PR TITLE
feat(link-manager): Add attachments feature

### DIFF
--- a/link_manager_app/index.html
+++ b/link_manager_app/index.html
@@ -44,6 +44,20 @@
                     <input type="number" id="trades-per-day" min="1" value="1">
                     <input type="range" id="trades-slider" min="1" max="10" value="1">
                 </div>
+                <div class="form-group">
+                    <label for="attachment-type">Attachment Type:</label>
+                    <select id="attachment-type">
+                        <option value="phone">Phone</option>
+                        <option value="url">URL</option>
+                        <option value="pdf">PDF</option>
+                        <option value="mp4">MP4</option>
+                        <option value="image">Image</option>
+                    </select>
+                    <label for="attachment-value">Value:</label>
+                    <input type="text" id="attachment-value">
+                    <button type="button" id="add-attachment-btn">Add Attachment</button>
+                </div>
+                <ul id="attachments-list"></ul>
                 <input type="hidden" id="editingId">
                 <button type="submit">Add Link</button>
             </form>
@@ -99,6 +113,20 @@
                     <label for="contact-name">Name:</label>
                     <input type="text" id="contact-name" required>
                 </div>
+                <div class="form-group">
+                    <label for="contact-attachment-type">Attachment Type:</label>
+                    <select id="contact-attachment-type">
+                        <option value="phone">Phone</option>
+                        <option value="url">URL</option>
+                        <option value="pdf">PDF</option>
+                        <option value="mp4">MP4</option>
+                        <option value="image">Image</option>
+                    </select>
+                    <label for="contact-attachment-value">Value:</label>
+                    <input type="text" id="contact-attachment-value">
+                    <button type="button" id="add-contact-attachment-btn">Add Attachment</button>
+                </div>
+                <ul id="contact-attachments-list"></ul>
                 <button type="submit">Add Contact</button>
             </form>
             <form id="connection-form">

--- a/link_manager_app/js/App.js
+++ b/link_manager_app/js/App.js
@@ -76,6 +76,26 @@ class App {
             this.handleLedgerFormSubmit();
         });
 
+        this.uiManager.addAttachmentBtn.addEventListener('click', () => {
+            const type = this.uiManager.attachmentTypeInput.value;
+            const value = this.uiManager.attachmentValueInput.value;
+            if (value) {
+                this.uiManager.attachments.push({ type, value });
+                this.uiManager.renderAttachments();
+                this.uiManager.attachmentValueInput.value = '';
+            }
+        });
+
+        this.contactUIManager.addAttachmentBtn.addEventListener('click', () => {
+            const type = this.contactUIManager.attachmentTypeInput.value;
+            const value = this.contactUIManager.attachmentValueInput.value;
+            if (value) {
+                this.contactUIManager.attachments.push({ type, value });
+                this.contactUIManager.renderAttachments();
+                this.contactUIManager.attachmentValueInput.value = '';
+            }
+        });
+
         document.getElementById('show-entire-ledger-btn').addEventListener('click', () => {
             this.handleShowEntireLedger();
         });
@@ -89,6 +109,7 @@ class App {
             const section = this.uiManager.sectionSelect.value;
             const tradesPerDay = this.uiManager.tradesPerDayInput.value;
             const notes = this.uiManager.notesInput.value;
+            const attachments = this.uiManager.attachments;
 
             if (!name || !link) {
                 NotificationService.showError('Name and link are required.');
@@ -101,7 +122,8 @@ class App {
                 link,
                 section,
                 tradesPerDay,
-                notes
+                notes,
+                attachments
             };
 
             if (editingId) {
@@ -194,9 +216,12 @@ class App {
     async handleContactFormSubmit() {
         const nameInput = document.getElementById('contact-name');
         const name = nameInput.value;
+        const attachments = this.contactUIManager.attachments;
         if (name) {
-            await this.contactManager.addContact({ name });
+            await this.contactManager.addContact({ name, attachments });
             nameInput.value = '';
+            this.contactUIManager.attachments = [];
+            this.contactUIManager.renderAttachments();
             NotificationService.showSuccess('Contact added successfully!');
         } else {
             NotificationService.showError('Contact name is required.');

--- a/link_manager_app/js/Contact.js
+++ b/link_manager_app/js/Contact.js
@@ -1,7 +1,8 @@
 export class Contact {
-    constructor({ id, name, connections }) {
+    constructor({ id, name, connections, attachments }) {
         this.id = id || Date.now();
         this.name = name;
         this.connections = connections || [];
+        this.attachments = attachments || [];
     }
 }

--- a/link_manager_app/js/ContactUIManager.js
+++ b/link_manager_app/js/ContactUIManager.js
@@ -5,6 +5,11 @@ export class ContactUIManager {
         this.connectionForm = document.getElementById('connection-form');
         this.contactSelect1 = document.getElementById('contact-select-1');
         this.contactSelect2 = document.getElementById('contact-select-2');
+        this.attachmentTypeInput = document.getElementById('contact-attachment-type');
+        this.attachmentValueInput = document.getElementById('contact-attachment-value');
+        this.addAttachmentBtn = document.getElementById('add-contact-attachment-btn');
+        this.attachmentsList = document.getElementById('contact-attachments-list');
+        this.attachments = [];
     }
 
     renderContacts(contacts) {
@@ -26,11 +31,34 @@ export class ContactUIManager {
             return connectedContact ? connectedContact.name : 'Unknown';
         }).join(', ');
 
+        const attachmentsHTML = contact.attachments.map(attachment => `
+            <div class="attachment-item">
+                <strong>${attachment.type}:</strong> ${attachment.value}
+            </div>
+        `).join('');
+
         contactElement.innerHTML = `
             <p><strong>${contact.name}</strong></p>
             <p>Connections: ${connections || 'None'}</p>
+            <div class="attachments">${attachmentsHTML}</div>
         `;
         return contactElement;
+    }
+
+    renderAttachments() {
+        this.attachmentsList.innerHTML = '';
+        this.attachments.forEach((attachment, index) => {
+            const li = document.createElement('li');
+            li.textContent = `${attachment.type}: ${attachment.value}`;
+            const removeBtn = document.createElement('button');
+            removeBtn.textContent = 'Remove';
+            removeBtn.onclick = () => {
+                this.attachments.splice(index, 1);
+                this.renderAttachments();
+            };
+            li.appendChild(removeBtn);
+            this.attachmentsList.appendChild(li);
+        });
     }
 
     populateConnectionSelects(contacts) {

--- a/link_manager_app/js/Link.js
+++ b/link_manager_app/js/Link.js
@@ -1,5 +1,5 @@
 export class Link {
-    constructor({ id, name, link, section, isEnabled, tradesPerDay, complete, ip, notes, ledger }) {
+    constructor({ id, name, link, section, isEnabled, tradesPerDay, complete, ip, notes, ledger, attachments }) {
         this.id = id || Date.now();
         this.name = name;
         this.link = link;
@@ -9,6 +9,7 @@ export class Link {
         this.ip = ip || false;
         this.notes = notes || '';
         this.ledger = ledger || [];
+        this.attachments = attachments || [];
         if (this.section === 'investing') {
             this.tradesPerDay = tradesPerDay || 1;
         }

--- a/link_manager_app/js/UIManager.js
+++ b/link_manager_app/js/UIManager.js
@@ -11,6 +11,10 @@ export class UIManager {
         this.tradesPerDayInput = document.getElementById('trades-per-day');
         this.tradesSlider = document.getElementById('trades-slider');
         this.notesInput = document.getElementById('notes');
+        this.attachmentTypeInput = document.getElementById('attachment-type');
+        this.attachmentValueInput = document.getElementById('attachment-value');
+        this.addAttachmentBtn = document.getElementById('add-attachment-btn');
+        this.attachmentsList = document.getElementById('attachments-list');
         this.modal = document.getElementById('actions-modal');
         this.iframe = document.getElementById('link-iframe');
         this.ledgerContainer = document.getElementById('ledger-container');
@@ -18,6 +22,7 @@ export class UIManager {
         this.ledgerForm = document.getElementById('ledger-form');
         this.currentLinkId = null;
         this.currentLedgerLinkId = null;
+        this.attachments = [];
     }
 
     showLedger(link) {
@@ -167,10 +172,17 @@ export class UIManager {
             `;
         }
 
+        const attachmentsHTML = link.attachments.map(attachment => `
+            <div class="attachment-item">
+                <strong>${attachment.type}:</strong> ${attachment.value}
+            </div>
+        `).join('');
+
         linkElement.innerHTML = `
             <div class="link-info">
                 <a href="${link.link}" target="_blank">${link.name}</a>
                 <p class="notes">${link.notes}</p>
+                <div class="attachments">${attachmentsHTML}</div>
                 ${investingInfo}
             </div>
             <div class="controls">
@@ -182,6 +194,22 @@ export class UIManager {
             </div>
         `;
         return linkElement;
+    }
+
+    renderAttachments() {
+        this.attachmentsList.innerHTML = '';
+        this.attachments.forEach((attachment, index) => {
+            const li = document.createElement('li');
+            li.textContent = `${attachment.type}: ${attachment.value}`;
+            const removeBtn = document.createElement('button');
+            removeBtn.textContent = 'Remove';
+            removeBtn.onclick = () => {
+                this.attachments.splice(index, 1);
+                this.renderAttachments();
+            };
+            li.appendChild(removeBtn);
+            this.attachmentsList.appendChild(li);
+        });
     }
 
     setupSectionToggle() {
@@ -207,6 +235,8 @@ export class UIManager {
         this.linkForm.reset();
         this.editingIdInput.value = '';
         this.notesInput.value = '';
+        this.attachments = [];
+        this.renderAttachments();
         this.tradesPerDayInput.value = 1;
         this.tradesSlider.value = 1;
         this.toggleInvestingOptions(false);
@@ -219,6 +249,8 @@ export class UIManager {
         document.getElementById('link').value = link.link;
         this.sectionSelect.value = link.section;
         this.notesInput.value = link.notes;
+        this.attachments = [...link.attachments];
+        this.renderAttachments();
 
         const isInvesting = link.section === 'investing';
         this.toggleInvestingOptions(isInvesting);


### PR DESCRIPTION
This commit adds a feature to attach various types of data to links and contacts.

The key changes include:
- Updating the `Link` and `Contact` data models to include an `attachments` array.
- Adding a new UI section to the link and contact forms for adding attachments.
- Updating the display of links and contacts to show their attachments.
- Updating the application logic to support adding and saving attachments.