### PR TITLE
Fix: Correct syntax error in UIManager class

### DIFF
--- a/best/alpha/ui.js
+++ b/best/alpha/ui.js
@@ -249,7 +249,6 @@ class UIManager {
             reportStatusDisplay.className = 'report-status';
         }
     }
-}
 
     showGeneralNotification(message, type = 'info', duration = 3000) {
         let notificationDiv = document.getElementById('general-notification');


### PR DESCRIPTION
The `showGeneralNotification` method was defined outside the `UIManager` class, and there was an extraneous closing brace, causing a syntax error.

This commit moves the `showGeneralNotification` method inside the `UIManager` class and removes the extra closing brace, allowing the script to be parsed and executed correctly.