### PR TITLE
feat: Add optional image recognition

### DIFF
--- a/best/alpha/index.html
+++ b/best/alpha/index.html
@@ -138,6 +138,9 @@
                             <label for="faceApiEnabled">Enable:</label>
                             <input type="checkbox" id="faceApiEnabled">
                         </div>
+                        <div class="control-group">
+                            <button id="scanAllButton">Scan All Visible</button>
+                        </div>
                     </fieldset>
                     <fieldset>
                         <legend>Iframe Recognition</legend>

--- a/best/alpha/script.js
+++ b/best/alpha/script.js
@@ -573,7 +573,8 @@
                     this.uiManager.hideOnlineLoadingIndicator.bind(this.uiManager),
                     this.#displayPreviousUsers.bind(this),
                     (birthdayStr, age) => this.#getDaysSinceOrUntil18thBirthday(birthdayStr, age),
-                    socialMedia // Add the new socialMedia object here
+                    socialMedia, // Add the new socialMedia object here
+                    this.#handleScanUser.bind(this)
                 );
                 fragment.appendChild(userElement);
             });
@@ -601,7 +602,8 @@
                     this.uiManager.hideOnlineLoadingIndicator.bind(this.uiManager),
                     this.#displayPreviousUsers.bind(this), 
                     (birthdayStr, age) => this.#getDaysSinceOrUntil18thBirthday(birthdayStr, age),
-                    socialMedia // Add the new socialMedia object here
+                    socialMedia, // Add the new socialMedia object here
+                    this.#handleScanUser.bind(this)
                 );
                 fragment.appendChild(userElement);
             });
@@ -789,7 +791,8 @@
                         this.uiManager.hideOnlineLoadingIndicator.bind(this.uiManager), 
                         this.#displayPreviousUsers.bind(this),
                         (birthdayStr, age) => this.#getDaysSinceOrUntil18thBirthday(birthdayStr, age),
-                        socialMedia // Add the new socialMedia object here
+                        socialMedia, // Add the new socialMedia object here
+                        this.#handleScanUser.bind(this)
                     );
                     fragment.appendChild(userElement);
                 });
@@ -863,6 +866,18 @@
                     console.error(`Failed to save previous users after removing ${username}:`, error);
                 }
             }
+        }
+
+        async #handleScanUser(username) {
+            if (!username) return;
+            const userElement = document.querySelector(`.user-info[data-username="${username}"]`);
+            if (!userElement) return;
+            const img = userElement.querySelector('img');
+            if (!img) return;
+
+            this.uiManager.showGeneralNotification(`Scanning ${username}...`, 'info', 2000);
+            await this.#processImage(img);
+            await this.#processImageWithOcr(img);
         }
 
         async #clearPreviousUsers() {
@@ -1126,6 +1141,12 @@
 
             this.ocrEnabled?.addEventListener('change', () => {
                 this.#toggleOcr();
+            });
+
+            document.getElementById('scanAllButton')?.addEventListener('click', () => {
+                this.uiManager.showGeneralNotification('Scanning all visible users...', 'info', 2000);
+                this.#processVisibleUserImages();
+                this.#processVisibleUserImagesWithOcr();
             });
         }
 

--- a/best/alpha/ui.js
+++ b/best/alpha/ui.js
@@ -22,17 +22,18 @@ class UIManager {
      * @returns {HTMLElement} The created user div element.
      */
     createUserElement(
-        user, 
-        listType, 
-        handleUserClickCallback, 
-        removeFromPreviousUsersCallback, 
+        user,
+        listType,
+        handleUserClickCallback,
+        removeFromPreviousUsersCallback,
         getUserClickCountCallback,
         isBirthdayCallback,
         showOnlineLoadingIndicatorCallback,
         hideOnlineLoadingIndicatorCallback,
         displayPreviousUsersCallback,
         getDaysSinceOrUntil18thBirthdayCallback, // Existing new callback
-        socialMediaData // Add new parameter for social media
+        socialMediaData, // Add new parameter for social media
+        handleScanUserCallback
     ) {
         const userElement = document.createElement("div");
         userElement.className = `user-info w3-card w3-margin-bottom ${listType}-list-item`;
@@ -97,17 +98,26 @@ class UIManager {
                 ${birthdayProximityHTMLString}
                 ${socialMediaHTML}
                 <p class="tags"><small>Tags: ${tagsDisplay}</small></p>
+                <button class="scan-user-btn w3-button w3-tiny w3-blue w3-hover-dark-grey" title="Scan user image">Scan</button>
                 ${birthdayBanner}
             </div>
         `;
 
         userElement.addEventListener("click", function(event) {
-            if (event.target.closest('.remove-user-btn')) {
+            if (event.target.closest('.remove-user-btn') || event.target.closest('.scan-user-btn')) {
                 return;
             }
             event.preventDefault();
             handleUserClickCallback(user);
         });
+
+        const scanBtn = userElement.querySelector('.scan-user-btn');
+        if (scanBtn) {
+            scanBtn.addEventListener("click", function(event) {
+                event.stopPropagation();
+                handleScanUserCallback(user.username);
+            });
+        }
 
         // const toggleBtn = userElement.querySelector('.toggle-view-btn');
         // if (toggleBtn) {


### PR DESCRIPTION
This commit adds the ability for you to trigger image recognition on a single user or on all visible users.

- Adds a 'Scan' button to each user card to trigger recognition for that user.
- Adds a 'Scan All' button to the settings to trigger recognition for all visible users.
- The global 'Enable' checkboxes for facial recognition and OCR still control model loading, but the new buttons trigger the processing on demand.