### PR TITLE
feat: Create BoxStore returns policy page

### DIFF
--- a/boxstore/index.html
+++ b/boxstore/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BoxStore - Returns Policy</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Returns Policy</h1>
+    </header>
+    <main>
+        <p>At BoxStore, we want you to be completely satisfied with your purchase. If you are not satisfied for any reason, we will gladly accept returns of merchandise within 30 days of purchase.</p>
+        <h2>How to Make a Return</h2>
+        <p>To make a return, please follow these steps:</p>
+        <ol>
+            <li>Package the item(s) securely in the original product packaging, if possible. Please include all paperwork, parts, and accessories.</li>
+            <li>Enclose the original packing slip with the item. If you cannot send your packing slip, please include your order number, billing name, and address with the item.</li>
+            <li>All products must be returned in good condition, to ensure full credit.</li>
+            <li>Ship the return package to:
+                <address>
+                    BoxStore Returns<br>
+                    123 Box Street<br>
+                    Boxington, BX 12345
+                </address>
+            </li>
+        </ol>
+        <h2>Refunds</h2>
+        <p>We will issue a full refund for the purchase price of the item, plus any applicable taxes, to the original form of payment. Please allow up to 14 business days for us to process your return and issue a refund.</p>
+        <h2>Exchanges</h2>
+        <p>At this time, we are unable to process exchanges. Please return the original item for a refund and place a new order for the desired item.</p>
+        <h2>Questions</h2>
+        <p>If you have any questions about our returns policy, please contact us at <a href="mailto:support@boxstore.com">support@boxstore.com</a>.</p>
+    </main>
+    <footer>
+        <p>&copy; 2025 BoxStore. All rights reserved.</p>
+    </footer>
+</body>
+</html>

--- a/boxstore/style.css
+++ b/boxstore/style.css
@@ -1,0 +1,26 @@
+body {
+    font-family: sans-serif;
+    line-height: 1.6;
+    margin: 20px;
+}
+
+header {
+    background-color: #f4f4f4;
+    padding: 1rem;
+    text-align: center;
+}
+
+h1 {
+    color: #333;
+}
+
+main {
+    padding: 1rem;
+}
+
+footer {
+    margin-top: 20px;
+    text-align: center;
+    font-size: 0.8em;
+    color: #666;
+}

--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
     // --- OOP, Decorators, Iterators, Generators, Async, IndexedDB, SVG, Animations ---
     // Directory/project data (static for now, could be loaded async from server or indexedDB)
     const PROJECTS = [
+      { name: 'BoxStore Returns', path: 'boxstore/', desc: 'Returns policy for BoxStore' },
       { name: '7t', path: '7t/', desc: 'Experimental text and alpha tools' },
       { name: 'best', path: 'best/', desc: 'Best strategies and alpha' },
       { name: 'beta', path: 'beta/', desc: 'Beta features and scripts' },


### PR DESCRIPTION
Creates a new directory and site for the BoxStore returns policy. Adds a link to the new page on the main index.html page.