### PR TITLE
feat: Create Craigslist job scraper

### DIFF
--- a/craigslist_scraper/README.md
+++ b/craigslist_scraper/README.md
@@ -1,0 +1,41 @@
+# Craigslist Job Scraper
+
+This script scrapes job postings from the software/qa/dba section of Craigslist for a specified city.
+
+## Setup
+
+1.  **Clone the repository or download the files.**
+2.  **Navigate to the `craigslist_scraper` directory:**
+    ```bash
+    cd craigslist_scraper
+    ```
+3.  **Install the required dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## How to Run
+
+To run the scraper, execute the following command in your terminal from within the `craigslist_scraper` directory:
+
+```bash
+python scraper.py
+```
+
+By default, it scrapes jobs from the San Francisco Bay Area (`sfbay`). You can modify the `city` parameter in the `scrape_craigslist_jobs()` function call at the bottom of `scraper.py` to scrape other cities.
+
+## Example Output
+
+The script will print the scraped job postings to the console, like this:
+
+```
+Scraping Craigslist jobs in sfbay...
+Found 8 jobs.
+Title: Web Designer/Developer Auction Website Design Start Today
+URL: https://sfbay.craigslist.org/scz/sof/d/menlo-park-web-designer-developer/7882577438.html
+--------------------
+Title: Koi Pond Maintenance Technician apprentice
+URL: https://sfbay.craigslist.org/sby/sof/d/san-jose-koi-pond-maintenance/7881252202.html
+--------------------
+...
+```

--- a/craigslist_scraper/requirements.txt
+++ b/craigslist_scraper/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/craigslist_scraper/scraper.py
+++ b/craigslist_scraper/scraper.py
@@ -1,0 +1,39 @@
+import requests
+from bs4 import BeautifulSoup
+
+def scrape_craigslist_jobs(city="sfbay"):
+    """
+    Scrapes job postings from a specific city on Craigslist using requests and BeautifulSoup.
+
+    :param city: The city to search for jobs in (e.g., "sfbay" for San Francisco Bay Area).
+    """
+    print(f"Scraping Craigslist jobs in {city}...")
+
+    # Navigate to the Craigslist jobs page
+    url = f"https://{city}.craigslist.org/d/software-qa-dba-etc/search/sof"
+    response = requests.get(url)
+
+    if response.status_code != 200:
+        print(f"Failed to retrieve the page. Status code: {response.status_code}")
+        return
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    # Find all the job postings
+    jobs = soup.find_all("li", class_="cl-static-search-result")
+    print(f"Found {len(jobs)} jobs.")
+
+    # Extract and print the job details
+    for job in jobs:
+        title_element = job.find("div", class_="title")
+        title = title_element.text.strip() if title_element else "N/A"
+
+        link_element = job.find("a")
+        url = link_element["href"] if link_element else "N/A"
+
+        print(f"Title: {title}")
+        print(f"URL: {url}")
+        print("-" * 20)
+
+if __name__ == "__main__":
+    scrape_craigslist_jobs()


### PR DESCRIPTION
This commit introduces a Python script to scrape job postings from Craigslist. The script is located in the `craigslist_scraper` directory and uses the `requests` and `BeautifulSoup4` libraries to fetch and parse job listings.

The solution includes:
- A Python script (`scraper.py`) to scrape job titles and URLs.
- A `requirements.txt` file listing the necessary dependencies.
- A `README.md` file with setup and usage instructions.